### PR TITLE
Fix MDX parsing error in network diagnostic tools

### DIFF
--- a/platform/network-diagnostic-tools.mdx
+++ b/platform/network-diagnostic-tools.mdx
@@ -12,6 +12,7 @@ Checkly provides:
 
 - **TCP Dumps:** capture network traffic to inspect packet-level behavior
 - **MTR (My Trace Route):** trace the path your request takes across the internet
+{/* - **Ping (ICMP):** test basic reachability and measure latency to a target host */}
 
 Whether you're debugging a slow response or tracing a connection failure, these tools help you get to the root of the problem.
 
@@ -56,4 +57,8 @@ MTR is currently only available for API checks.
 </Note>
 
 On failed checks, an MTR report is displayed directly in the Network Diagnostics section of the check results page. The table shows each hop, its IP or hostname, along with metrics such as packet loss, latency, and jitter.
+
+{/* ### Ping (ICMP)
+
+[coming in Q4 2025] */}
 


### PR DESCRIPTION
- Remove problematic HTML comments that caused MDX parsing to fail
- Comments with '\!' characters inside MDX were causing parser errors
- Page should now load correctly

🤖 Generated with [Claude Code](https://claude.ai/code)