### PR TITLE
fix: converting links from HTML to MD in the openapi.json

### DIFF
--- a/update-api-spec.sh
+++ b/update-api-spec.sh
@@ -31,14 +31,14 @@ echo "🔧 Cleaning up HTML in descriptions..."
 # Use cross-platform sed syntax (works on both macOS and Linux)
 if sed --version 2>&1 | grep -q GNU; then
   # GNU sed (Linux)
-  sed -i 's|<a href="\([^"]*\)" target="_blank">here</a>|[here](\1)|g' "$TEMP_CONVERTED"
+  sed -i 's|<a[^>]*href=\\"\([^"]*\)\\"[^>]*>\([^<]*\)</a>|[\2](\1)|g' "$TEMP_CONVERTED"
   sed -i 's|</br>|\n|g' "$TEMP_CONVERTED"
   sed -i 's|<br>|\n|g' "$TEMP_CONVERTED"
   sed -i 's|<b>\([^<]*\)</b>|**\1**|g' "$TEMP_CONVERTED"
   sed -i 's|<code>\([^<]*\)</code>|`\1`|g' "$TEMP_CONVERTED"
 else
   # BSD sed (macOS)
-  sed -i.tmp 's|<a href="\([^"]*\)" target="_blank">here</a>|[here](\1)|g' "$TEMP_CONVERTED"
+  sed -i.tmp 's|<a[^>]*href=\\"\([^"]*\)\\"[^>]*>\([^<]*\)</a>|[\2](\1)|g' "$TEMP_CONVERTED"
   sed -i.tmp 's|</br>|\n|g' "$TEMP_CONVERTED"
   sed -i.tmp 's|<br>|\n|g' "$TEMP_CONVERTED"
   sed -i.tmp 's|<b>\([^<]*\)</b>|**\1**|g' "$TEMP_CONVERTED"


### PR DESCRIPTION
Our API reference is showing unparsed link HTML:

<img width="1500" height="837" alt="image" src="https://github.com/user-attachments/assets/163ad37d-970a-4cd7-b365-26374b0fed5b" />

I updated the script that converts the HTML to MD, so that links are now properly converted.

I've tested the updated sed command in isolation and the script locally, both work.

<img width="3252" height="850" alt="CleanShot 2025-10-02 at 16 26 27@2x" src="https://github.com/user-attachments/assets/5b7c681b-3697-4b1d-82a4-b614cd8e6420" />