### PR TITLE
feat(playwright): add documentation about retryStrategy [kit-2263]

### DIFF
--- a/detect/synthetic-monitoring/playwright-checks/configuration.mdx
+++ b/detect/synthetic-monitoring/playwright-checks/configuration.mdx
@@ -106,7 +106,7 @@ A Playwright Check Suite inherits multiple properties from [the abstract `Check`
 Check [the reference documentation](/constructs/project#param-checks-playwright-checks) for more information on these settings.
 
 <Note>
-**Retry strategy is not supported for Playwright checks.** Playwright has built-in retry mechanisms that you can configure directly in your `playwright.config.ts/js` file using the [`retries`](https://playwright.dev/docs/test-retries) option. This provides more granular control over test retries at the Playwright level.
+**Checks' Retry strategy is not applicable for Playwright checks.** Playwright includes its own retry features that can be set up directly in your `playwright.config.ts/js` file with the [`retries`](https://playwright.dev/docs/test-retries) option. This allows for more detailed management of test retries within Playwright, when your check runs.
 </Note>
 
 Additionally, Playwright Check Suites provide specific configuration for your Playwright monitoring.


### PR DESCRIPTION
Add documentation about why "retryStrategy" is not supported for Playwright checks.

<img width="669" height="150" alt="Screenshot 2025-10-08 at 11 12 19" src="https://github.com/user-attachments/assets/48aeb657-30e8-4e95-a4a6-19c20725e017" />
