### PR TITLE
updated network troubleshooting section

### DIFF
--- a/platform/network-diagnostic-tools.mdx
+++ b/platform/network-diagnostic-tools.mdx
@@ -4,7 +4,7 @@ description: 'Network Diagnostic Tools in Checkly'
 sidebarTitle: 'Network Diagnostic Tools'
 ---
 
-When troubleshooting network issues like DNS resolution failures, dropped packets, or broken TCP handshakes you often require low-level visibility into what's happening on the network.
+When troubleshooting network issues like dropped packets or broken TCP handshakes you often require low-level visibility into what's happening on the network.
 
 That's where network diagnostic tools come in. They help you understand how data moves through a network and where things might be breaking down.
 
@@ -23,7 +23,6 @@ TCP dumps give you a detailed look at what's happening at the packet level when 
 - Did the TCP handshake complete?
 - Was the TLS handshake successful?
 - Were packets dropped, delayed, or malformed?
-- Did DNS resolution succeed?
 
 This level of visibility is especially helpful for diagnosing flaky networking behavior.
 


### PR DESCRIPTION
TCP dumps do not include any info on DNS traffic - this PR makes sure the docs don't reflect otherwise.