### PR TITLE
fix: Traces demo video not embded properly (#73)

### DIFF
--- a/resolve/traces/overview.mdx
+++ b/resolve/traces/overview.mdx
@@ -44,11 +44,15 @@ Export check results as traces to your 3rd party OTel tooling
 
 See this in action in the video below:
 
-<video
-  controls
-  className="w-full aspect-video rounded-xl"
-  src="https://www.loom.com/share/30c143388ba54e9ba6b665dfbfe0d295?sid=8f40177a-c708-410f-b73c-6faf50dc7c75"
-></video>
+<Frame>
+  <iframe 
+    src="https://www.loom.com/embed/30c143388ba54e9ba6b665dfbfe0d295?sid=8ad8d273-b0bb-48ca-b456-1b137384b9de" 
+    title="Embedded content"
+    className="w-full aspect-video rounded-xl"
+    frameBorder="0"
+    allowfullscreen
+  ></iframe>
+</Frame>
 
 ## Key Benefits
 


### PR DESCRIPTION
## Affected Components

* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

## Notes for the Reviewer
* Fix the embed for Traces demo video on /resolve/traces/overview
