### PR TITLE
Update API check assertions documentation

### DIFF
--- a/detect/synthetic-monitoring/api-checks/assertions.mdx
+++ b/detect/synthetic-monitoring/api-checks/assertions.mdx
@@ -70,12 +70,6 @@ Response time is empty? JSON Object is less than? We block out the comparisons w
 - Less than
 - Contains / Not contains
 - Is null / Not null
-- Has key / Not has key (deprecated)
-- Has value / Not has value (deprecated)
-
-<Warning>
-The **Has key** and **Has value** comparison are deprecated. They belong to our [old style of asserting JSON objects]() before we introduced JSON Path
-</Warning>
 
 ## Target
 
@@ -217,14 +211,6 @@ In the last example we check if the returned array has more than 10 items.
 > For example, if the JSON path expression returns an array: `[1,5,2]`, and we use a `Less than` comparison, with `3` 
 > as the target, the assertion **will fail**, because the comparison is **falsy** for the second element of the array 
 > (`5` is greater than `3`).
-
-## Deprecated: Custom, non-JSON path properties
-
-Before we released the feature to use JSON path queries, Checkly had a custom way of querying the contents of a JSON
-response body.
-
-This method is still available for backwards compatibility reasons, but no longer advised as it is much less flexible and 
-powerful.
 
 ## Using regular expressions
 


### PR DESCRIPTION
- Remove deprecated HAS_KEY/HAS_VALUE comparisons (no longer available in UI)

- Remove outdated "Custom, non-JSON path properties" section (To quote Daniel "Then there is another part talking about sth. deprecated that I dont even know what it was, lets remove that?")

Are there any other bits in the assertion docs that we should be updating? For reference: https://www.checklyhq.com/docs/detect/synthetic-monitoring/api-checks/assertions/
