### PR TITLE
Update Checkly Agent versions and runtimes

### DIFF
--- a/platform/private-locations/agent-configuration.mdx
+++ b/platform/private-locations/agent-configuration.mdx
@@ -154,14 +154,16 @@ docker run -v ~/certificate.pem:/checkly/certificate.pem -e NODE_EXTRA_CA_CERTS=
 
 Each Checkly Agent only supports specific [runtimes](/platform/runtimes/overview/). This is to keep the container image at an acceptable size. When you change the runtime a check uses, you may also need to change to the corresponding agent version. Similarly, if you update the agent version to one using a different runtime you also need to update your checks to use the same runtime.
 
-| Runtime | Agent versions |
-|---------|---------------|
-| 2025.04 | 5.0.0, 6.0.0 |
-| 2024.09 | 3.5.0, 4.0.0, 6.0.0 |
-| 2024.02 | 3.4.0 |
-| 2023.09 | 3.2.0 |
-| 2023.02 | 2.0.0 |
-| 2022.10 | 1.3.9 |
+| Agent version | Runtimes |
+|---------------|----------|
+| 6.0.0 | 2025.04, 2024.09 |
+| 5.0.0 | 2025.04 |
+| 4.0.0 | 2024.09 |
+| 3.5.0 | 2024.09 |
+| 3.4.0 | 2024.02 |
+| 3.2.0 | 2023.09 |
+| 2.0.0 | 2023.02 |
+| 1.3.9 | 2022.10 |
 
 As each agent version only supports specific runtimes, we recommend pinning agent versions used in production.
 


### PR DESCRIPTION
## Affected Components

* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

Updated the Checkly Agent supported runtimes for the most recent agent and runtime versions, according to our [changelog](https://feedback.checklyhq.com/changelog?c=Checkly+Agent).

Also tweaked the verbiage to account for our multi-runtime agents.

I didn't touch the older agent versions/runtimes. In the future, it would be nice to be more specific with the agent versions, but I didn't have time to test/verify those.