### PR TITLE
Update dynamic-secret-scrubbing.mdx

### DIFF
--- a/platform/dynamic-secret-scrubbing.mdx
+++ b/platform/dynamic-secret-scrubbing.mdx
@@ -13,7 +13,7 @@ Set environment variables with the `CHECKLY_SECRET_*` prefix and the runtime wil
 ## How it works
 
 <Warning>
-Currently, secret scrubbing is only supported for Browser, API and Multi-Step Checks.
+Currently, dynamic secret scrubbing is only supported for Browser and Multi-Step Checks.
 </Warning>
 
 Assign values to `process.env.CHECKLY_SECRET_*` in your check code:
@@ -48,7 +48,7 @@ process.env.CHECKLY_SECRET_PAYMENT_KEY = await vault.get('payment-api-key')
 
 ## Limitations
 
-- **Check types**: Only works in browser, API and multistep checks
+- **Check types**: Only works in browser and multistep checks
 - **Value format**: Must be a string (empty strings, `null`, `undefined`, numbers, objects, and arrays are ignored)
 - **Size limit**: Values cannot exceed 128KB (~128,000 characters)
 - **Pattern-based detection**: Scrubbing works by detecting code and output structures. Complex or unconventional Playwright usage may fall outside of this detection. Follow the documented patterns for reliable scrubbing.


### PR DESCRIPTION
Based on the following feedback: "Since the page is specifically about dynamic secret scrubbing, we might want to update this to include "dynamic", the reason is that secret scrubbing in general supports API checks as well, dynamic scrubbing not"