### PR TITLE
Fix prose-card-styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -21,7 +21,7 @@ th {
   font-size: 1.3rem;
 }
 
-.prose :where(a):not(:where([class~=not-prose],[class~=not-prose] *)) {
+.prose :where(a):not(:where([class~=not-prose],[class~=not-prose] *,.card)) {
   border: none;
   text-decoration: underline;
   text-decoration-thickness: 0.1em;
@@ -30,10 +30,10 @@ th {
   text-decoration-color: rgb(var(--primary));
 }
 
-.prose :where(a code):not(:where([class~=not-prose],[class~=not-prose] *)) {
+.prose :where(a code):not(:where([class~=not-prose],[class~=not-prose] *,.card)) {
   text-decoration: none;
 }
 
-.prose :where(a):not(:where([class~=not-prose],[class~=not-prose] *)) {
+.prose :where(a):not(:where([class~=not-prose],[class~=not-prose] *,.card)) {
   text-decoration-color: currentColor;
 }


### PR DESCRIPTION
## Affected Components

* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

This hopefully fixes broken card styles in prod.

<img width="700" height="549" alt="grafik" src="https://github.com/user-attachments/assets/53d65735-7a22-48c8-914e-75c038515b87" />

The problem is that it worked locally and only was an issue in prod. Let's see how the preview deploy looks like.
