### PR TITLE
Remove incorrect information about custom schedules

### DIFF
--- a/detect/synthetic-monitoring/playwright-checks/overview.mdx
+++ b/detect/synthetic-monitoring/playwright-checks/overview.mdx
@@ -90,7 +90,7 @@ Learn more about [test organization strategies](/detect/synthetic-monitoring/pla
 
 Customize how your checks run:
 
-- **Frequency**: Schedule from every minute to custom intervals
+- **Frequency**: Schedule runs at regular intervals
 - **Locations**: Deploy to multiple global regions
 - **Alerting**: Set up notifications and escalation
 - **Dependencies**: Use private packages and custom registries (see [custom dependencies](/detect/synthetic-monitoring/playwright-checks/custom-dependencies))

--- a/quickstarts/heartbeat-monitor.mdx
+++ b/quickstarts/heartbeat-monitor.mdx
@@ -46,10 +46,9 @@ The timing configuration is the heart of your heartbeat monitor. You need to spe
 
 The **period** defines how often your task should ping Checkly:
 
-- **Daily jobs**: Set to 24 hours
+- **Daily jobs**: Set to 1 day
 - **Weekly jobs**: Set to 7 days
 - **Hourly jobs**: Set to 1 hour
-- **Custom schedules**: Set to match your cron schedule
 
 ![Configure period and grace settings for your heartbeat monitor](/images/heartbeat-monitors/getting-started-period-and-grace.png)
 


### PR DESCRIPTION
## Affected Components

* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [X] Docs
* [ ] Learn
* [ ] Other

Ref: https://linear.app/checklyhq/issue/DOC-45/remove-misleading-phrasing-about-custom-frequencies