### PR TITLE
docs: add uptime calculation explanation for status pages [ship]

### DIFF
--- a/communicate/status-pages/overview.mdx
+++ b/communicate/status-pages/overview.mdx
@@ -28,9 +28,9 @@ A service can be used by multiple status pages. When an incident is opened for a
 
 ### Connecting Services and Status Pages
 
-To display a service on a Status Page, go to the Status Page editor and open the `Services` dropdown on the card you want to display your service on. 
+To display a service on a Status Page, go to the Status Page editor and open the `Services` dropdown on the card you want to display your service on.
 
-Select your service from the list and save your Status Page. The page will now display the selected service. 
+Select your service from the list and save your Status Page. The page will now display the selected service.
 
 You can also create new services directly from the dropdown by entering a new service name and pressing `Create`.
 
@@ -39,6 +39,39 @@ You can display the same service on multiple pages. An incident declared on that
 ### Connecting Checks to Service to automate Incidents (paid plans)
 
 A Check can also be associated with a Service, and automatically open Incidents whenever it fails. [See incident automation for more details](/communicate/status-pages/incidents#incident-automation).
+
+## Uptime calculation
+
+Status pages display an uptime percentage for each service, as well as an overall uptime for each card. Here's how these values are calculated:
+
+### Time window
+
+Uptime is calculated based on the **last 90 days** of data. This provides a meaningful long-term view of service reliability while remaining recent enough to reflect current performance.
+
+### Service uptime
+
+Service uptime represents the percentage of time the service was operational within the 90-day window. The calculation is:
+
+```
+Uptime = ((Total time - Downtime) / Total time) × 100
+```
+
+For example, if a service had 1 day of downtime over 90 days, the uptime would be approximately 98.89%.
+
+### Card uptime
+
+The uptime shown for a card is the **average uptime** of all services displayed within that card.
+
+### What affects uptime
+
+Uptime is determined by **incidents**, not directly by check results. Here's how it works:
+
+- **Manual incidents**: When you [create an incident](/communicate/status-pages/incidents#creating-an-incident) affecting a service, the incident duration counts as downtime.
+- **Automated incidents**: When [incident automation](/communicate/status-pages/incidents#incident-automation) is enabled for a check, any check failure that triggers an alert will automatically open an incident, which counts as downtime. The incident is resolved when the check recovers.
+
+<Note>
+If you don't have incident automation enabled, check failures won't automatically affect your uptime. You would need to manually create incidents to reflect downtime in your uptime calculations.
+</Note>
 
 ## Best practices for status pages
 


### PR DESCRIPTION
## Summary
- Adds documentation explaining how uptime is calculated for status pages
- Explains that uptime is based on the last 90 days
- Clarifies that card uptime is the average of all service uptimes
- Documents that uptime is determined by incidents, not directly by check results