### PR TITLE
docs: clarify metrics not included in Coralogix integration

### DIFF
--- a/integrations/observability/coralogix.mdx
+++ b/integrations/observability/coralogix.mdx
@@ -55,6 +55,9 @@ Each trace will have the following metadata added to it as **tags**:
 Using these tags, you can create filters, dashboards and slice & dice your Checkly data as your runs are executed and
 ingested into Coralogix as traces.
 
+If you are using a different trace header than the standard `traceparent`, you can configure this header in the *custom 
+trace header* field in the integration settings.
+
 ### What's included
 
 - Traces for every check execution
@@ -66,9 +69,6 @@ Check **metrics** (response times, availability, etc.) are not sent through this
 to Coralogix, scrape them via the [Prometheus integration](https://www.checklyhq.com/docs/integrations/observability/prometheus-v2/)
 and forward to Coralogix using an OpenTelemetry Collector.
 </Note>
-
-If you are using a different trace header than the standard `traceparent`, you can configure this header in the *custom 
-trace header* field in the integration settings.
 
 ## RUM integration
 


### PR DESCRIPTION
Added a "What's included" section to clarify that the Coralogix OTEL integration only sends traces, not metrics.

Users who want metrics in Coralogix can use the Prometheus integration + OTEL Collector.