### PR TITLE
fix: add redirect for constructs/quickstarts/playwright-check

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1222,6 +1222,10 @@
     {
       "source": "/communicate/alerts/webhooks",
       "destination": "/integrations/alerts/webhooks"
+    },
+    {
+      "source": "/constructs/quickstarts/playwright-check",
+      "destination": "/quickstarts/playwright-check"
     }
   ]
 


### PR DESCRIPTION
Redirect the old path to /quickstarts/playwright-check.

## Affected Components

* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ ] Docs
* [ ] Learn
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->

## Screenshots
<!-- Screenshot of any visual changes -->
