### PR TITLE
Fix typo: remove duplicate words in synthetic monitoring description …

### DIFF
--- a/learn/monitoring/synthetic-monitoring.mdx
+++ b/learn/monitoring/synthetic-monitoring.mdx
@@ -18,7 +18,7 @@ Synthetic monitoring enables software teams to better understand the performance
 Just as automated testing is essential for high-velocity development teams, enabling them to catch bugs and defects by simulating real user flows in testing and preview environments, synthetic monitoring enables teams to continuously monitor for optimal user experiences. Some synthetic monitoring tools, like Checkly, allow engineers to reuse entire end-to-end tests as production monitors. This enables true continuous quality to be practiced by organizations.
 
 ## How does Synthetic Monitoring work?
-At its core, synthetic monitoring is about simulating user interactions with an application to preemptively identify issues before they impact real users. Synthetic monitoring gives developers and operations engineers the confidence that they are one stay one step ahead, ensuring that potential problems are identified and resolved swiftly.
+At its core, synthetic monitoring is about simulating user interactions with an application to preemptively identify issues before they impact real users. Synthetic monitoring gives developers and operations engineers the confidence that they are one step ahead, ensuring that potential problems are identified and resolved swiftly.
 
 In practice, synthetic monitoring works a lot like automated testing in production. Teams constantly run “tests” against a production environment from global locations. Using a Monitoring as Code workflow, its easy to even reuse real end-to-end tests as monitors, simply by deploying them to infrastructure such as Checkly.
 


### PR DESCRIPTION
…(synthetic-monitoring.mdx)

"one stay one step ahead" corrected to "one step ahead" in synthetic-monitoring.mdx
Affected Components: Docs