### PR TITLE
Add troubleshooting section to TCP docs

### DIFF
--- a/detect/uptime-monitoring/tcp-monitors/overview.mdx
+++ b/detect/uptime-monitoring/tcp-monitors/overview.mdx
@@ -48,3 +48,18 @@ Select a specific check run to review its results:
   * Data: Time taken to send the payload and receive the response data
 
 Learn more in our documentation on [Results](/concepts/results).
+
+## Troubleshooting
+
+<Accordion title="TCP monitors on port 25 time out">
+TCP monitors to port 25 (SMTP) may fail with a SOCKET_TIMEOUT error from some Checkly locations.
+
+This happens because [AWS blocks outbound traffic on port 25 by default to prevent spam](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-resource-limits.html#port-25-throttle). Some Checkly public locations run on AWS, so connections to port 25 cannot be established from those regions.
+
+**Workarounds:**
+
+* Run the check from a [Private Location](/platform/private-locations/overview) where port 25 is allowed
+
+* Use an alternative SMTP port such as 587 or 465 if supported
+
+</Accordion>


### PR DESCRIPTION
## Affected Components

* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

## Summary

TCP monitors to port 25 (SMTP) may fail with a SOCKET_TIMEOUT error from some Checkly locations.

This happens because [AWS blocks outbound traffic on port 25 by default to prevent spam](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-resource-limits.html#port-25-throttle). Some Checkly public locations run on AWS, so connections to port 25 cannot be established from those regions.

**Workarounds:**

* Run the check from a [Private Location](/platform/private-locations/overview) where port 25 is allowed

* Use an alternative SMTP port such as 587 or 465 if supported

## Internal Reference

https://checklyhq.slack.com/archives/C024ZAJ938S/p1772620784489899

