### PR TITLE
Add `checkly skills` CLI reference page

### DIFF
--- a/cli/checkly-skills.mdx
+++ b/cli/checkly-skills.mdx
@@ -1,0 +1,64 @@
+---
+title: checkly skills
+description: 'Print Checkly project, CLI and workflow context as Markdown for AI agents and LLMs.'
+sidebarTitle: 'checkly skills'
+---
+
+<Note>Available since CLI v7.5.0.</Note>
+
+The `checkly skills` command outputs Markdown-formatted context about your Checkly project, describing monitoring capabilities and how to use them programmatically. **This context is designed to be discovered and consumed by AI agents and LLMs**, giving them the information they need to work with your monitoring setup.
+
+You can also install [Checkly Skills as an agent skill](/integrations/ai/skills) to let your AI agent automatically discover and use the `checkly skills` command.
+
+<Accordion title="Prerequisites">
+Before using `checkly skills`, ensure you have:
+
+- Checkly CLI installed
+
+No existing Checkly account is required to access Checkly skills and documentation.
+</Accordion>
+
+## Usage
+
+`checkly skills` provides your agent with all the required information to manage your Checkly monitoring setup. All resources and workflows are discoverable to provide your agent the right information at the right time.
+
+```bash Terminal
+npx checkly skills
+npx checkly skills <action> [resource]
+```
+
+## Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `initialize` | Let your agent initialize [a new Checkly project](/constructs/project). |
+| `configure` | Let your agent configure [Checkly constructs](/constructs/overview). |
+
+## `checkly skills initialize` (experimental)
+
+The `initialize` subcommand outputs LLM-optimized Markdown with all the context an agent needs to set up a new Checkly project from scratch. The context will instruct your agent to install required packages, create config files and scan your current project for resources to monitor.
+
+**Usage:**
+
+```bash Terminal
+npx checkly skills initialize
+```
+
+<Tip>
+You can prompt your agent with **"run `npx checkly skills initialize` and follow the instructions"** and the agent will have everything it needs to scaffold your Checkly monitoring setup.
+</Tip>
+
+## `checkly skills configure [resource]`
+
+The `configure` subcommand is an umbrella command that provides Markdown context about all available Checkly resources. The CLI outputs everything your agent needs to configure [Checkly constructs](/constructs/overview) directly — no additional docs fetching or file reading required.
+
+Run `configure` without arguments to see all available resources, or pass a specific resource name to get targeted context.
+
+**Usage:**
+
+```bash Terminal
+npx checkly skills configure
+npx checkly skills configure api-checks
+npx checkly skills configure browser-checks
+# ...and more
+```

--- a/docs.json
+++ b/docs.json
@@ -542,6 +542,7 @@
               "cli/checkly-logout",
               "cli/checkly-pw-test",
               "cli/checkly-runtimes",
+              "cli/checkly-skills",
               "cli/checkly-status-pages",
               "cli/checkly-switch",
               "cli/checkly-sync-playwright",

--- a/integrations/ai/skills.mdx
+++ b/integrations/ai/skills.mdx
@@ -16,15 +16,18 @@ npx skills add checkly/checkly-cli
 
 This will make the Checkly Skills available to your AI agent. When your agent needs to perform a Checkly-related task, it can automatically pull in the relevant context and use the provided instructions and resources to execute the task effectively.
 
-```txt Claude Code Example highlight={3-4, 6}
+```txt Claude Code Example highlight={3-4, 8-9}
 ❯ Can you create a new URLMonitor with Checkly for example.com?
 
-⏺ Skill(monitoring)
-  ⎿ Successfully loaded skill · 2 tools allowed
+⏺ Skill(checkly)
+  ⎿ Successfully loaded skill · 3 tools allowed
 
-⏺ Let me read the monitors reference and check the existing project structure
+⏺ Let me read more references and check the existing project structure
 
-⏺ Searched for 1 pattern, read 2 files
+⏺ Bash(npx checkly skills configure)
+⏺ Bash(npx checkly skills configure url-monitors)
+
+⏺ Searched for 1 pattern, executed 2 commands
 
 ⏺ I'll create a new URLMonitor for example.com!
 ```
@@ -33,6 +36,7 @@ Using [Monitoring as Code](/concepts/monitoring-as-code), you can now control yo
 
 ## Additional resources
 
+- [`checkly skills` CLI Reference](/cli/checkly-skills)
 - [Checkly CLI Documentation](/cli/overview/)
 - [Checkly Constructs Reference](/constructs/overview/)
 - [Agent Skills Specification](https://agentskills.io/specification.md)


### PR DESCRIPTION
## Summary

When it comes to the general `skills` documentation, I only made some minor tweaks because we still want to ship `npx checkly skills install` and need to test out the AI-first `init command.

------

- Adds a new CLI reference page for the `checkly skills` command (available since CLI v7.5.0)
- Documents the `initialize` and `configure` subcommands with usage examples
- Updates the skills integration page with a revised Claude Code example and a link to the new CLI reference
- Adds cross-links between the CLI reference and the integration page
