### PR TITLE
docs: standardize CLI command reference consistency

### DIFF
--- a/cli/checkly-checks.mdx
+++ b/cli/checkly-checks.mdx
@@ -42,15 +42,15 @@ npx checkly checks list [options]
 
 **Options:**
 
-| Option | Description |
-|--------|-------------|
-| `--limit, -l` | Number of checks to return (1-100). Default: `25`. |
-| `--page, -p` | Page number. Default: `1`. |
-| `--search, -s` | Filter checks by name (case-insensitive). |
-| `--tag, -t` | Filter by tag. Can be specified multiple times. |
-| `--type` | Filter by check type. |
-| `--hide-id` | Hide check IDs in table output. |
-| `--output, -o` | Output format: `table`, `json`, or `md`. Default: `table`. |
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--limit, -l` | - | Number of checks to return (1-100). Default: `25`. |
+| `--page, -p` | - | Page number. Default: `1`. |
+| `--search, -s` | - | Filter checks by name (case-insensitive). |
+| `--tag, -t` | - | Filter by tag. Can be specified multiple times. |
+| `--type` | - | Filter by check type. |
+| `--hide-id` | - | Hide check IDs in table output. |
+| `--output, -o` | - | Output format: `table`, `json`, or `md`. Default: `table`. |
 
 ### List Options
 
@@ -177,17 +177,17 @@ npx checkly checks get <id> [options]
 
 | Argument | Description |
 |----------|-------------|
-| `ID` | The ID of the check to retrieve. |
+| `id` | The ID of the check to retrieve. |
 
 **Options:**
 
-| Option | Description |
-|--------|-------------|
-| `--result, -r` | Show details for a specific result ID. |
-| `--error-group, -e` | Show full details for a specific error group ID. |
-| `--results-limit` | Number of recent results to show. Default: `10`. |
-| `--results-cursor` | Cursor for results pagination (from previous output). |
-| `--output, -o` | Output format: `detail`, `json`, or `md`. Default: `detail`. |
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--result, -r` | - | Show details for a specific result ID. |
+| `--error-group, -e` | - | Show full details for a specific error group ID. |
+| `--results-limit` | - | Number of recent results to show. Default: `10`. |
+| `--results-cursor` | - | Cursor for results pagination (from previous output). |
+| `--output, -o` | - | Output format: `detail`, `json`, or `md`. Default: `detail`. |
 
 ### Get Options
 

--- a/cli/checkly-deploy.mdx
+++ b/cli/checkly-deploy.mdx
@@ -19,15 +19,15 @@ The basic command deploys all resources to your Checkly account, synchronizing y
 npx checkly deploy [options]
 ```
 
-| Option | Description |
-|--------|-------------|
-| `--config, -c` | The Checkly CLI configuration file. If not passed, uses the `checkly.config.ts\|js` file in the current directory. |
-| `--force, -f` | Force mode. Skips the confirmation dialog. |
-| `--debug-bundle` | Generate a JSON file containing the data sent to our servers when you deploy. **Note**: This flag is in beta. The bundle’s structure is not considered a stable format and may change without notice. It’s intended for one-off troubleshooting, and note it may contain secrets before sharing. |
-| `--output, -o` | Show the changes made after the deploy command. |
-| `--preview, -p` | Show a preview of the changes made by the deploy command. |
-| `--[no-]schedule-on-deploy` | Enables automatic check scheduling after a deploy. |
-| `--[no-]verify-runtime-dependencies` | Return an error if checks import dependencies that are not supported by the selected runtime. |
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--config, -c` | - | The Checkly CLI configuration file. If not passed, uses the `checkly.config.ts\|js` file in the current directory. |
+| `--force, -f` | - | Force mode. Skips the confirmation dialog. |
+| `--debug-bundle` | - | Generate a JSON file containing the data sent to our servers when you deploy. **Note**: This flag is in beta. The bundle’s structure is not considered a stable format and may change without notice. It’s intended for one-off troubleshooting, and note it may contain secrets before sharing. |
+| `--output, -o` | - | Show the changes made after the deploy command. |
+| `--preview, -p` | - | Show a preview of the changes made by the deploy command. |
+| `--[no-]schedule-on-deploy` | - | Enables automatic check scheduling after a deploy. |
+| `--[no-]verify-runtime-dependencies` | - | Return an error if checks import dependencies that are not supported by the selected runtime. |
 
 ## Command Options
 

--- a/cli/checkly-destroy.mdx
+++ b/cli/checkly-destroy.mdx
@@ -22,10 +22,10 @@ The basic command destroys all project resources with a confirmation prompt.
 npx checkly destroy [options]
 ```
 
-| Option | Description |
-|--------|-------------|
-| `--config, -c` | The Checkly CLI configuration file. If not passed, uses the `checkly.config.ts\|js` file in the current directory. |
-| `--force, -f` | Force mode. Skips the confirmation dialog. |
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--config, -c` | - | The Checkly CLI configuration file. If not passed, uses the `checkly.config.ts\|js` file in the current directory. |
+| `--force, -f` | - | Force mode. Skips the confirmation dialog. |
 
 ## Command Options
 

--- a/cli/checkly-env.mdx
+++ b/cli/checkly-env.mdx
@@ -40,10 +40,10 @@ npx checkly env add <key> <value> [options]
 
 **Options:**
 
-| Option | Description |
-|--------|-------------|
-| `--locked, -l` | Lock variable. |
-| `--secret, -s` | Store as secret. |
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--locked, -l` | - | Lock variable. |
+| `--secret, -s` | - | Store as secret. |
 
 **Examples:**
 
@@ -70,10 +70,10 @@ npx checkly env update <key> <value> [options]
 
 **Options:**
 
-| Option | Description |
-|--------|-------------|
-| `--locked, -l` | Lock variable. |
-| `--secret, -s` | Store as secret. |
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--locked, -l` | - | Lock variable. |
+| `--secret, -s` | - | Store as secret. |
 
 **Examples:**
 
@@ -119,9 +119,9 @@ npx checkly env pull [filename] [options]
 
 **Options:**
 
-| Option | Description |
-|--------|-------------|
-| `--force, -f` | Overwrite existing file without confirmation |
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--force, -f` | - | Overwrite existing file without confirmation |
 
 **Examples:**
 
@@ -148,9 +148,9 @@ npx checkly env rm <key> [options]
 
 **Options:**
 
-| Option | Description |
-|--------|-------------|
-| `--force, -f` | Skip confirmation dialog |
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--force, -f` | - | Skip confirmation dialog |
 
 **Examples:**
 

--- a/cli/checkly-import.mdx
+++ b/cli/checkly-import.mdx
@@ -48,10 +48,10 @@ npx checkly import check:2ce8...
 
 `npx checkly import` starts an interactive process that generates an import plan, applies it to create Check files, and commits the changes to mark resources as managed by your CLI project.
 
-| Option | Description |
-|--------|-------------|
-| `--config, -c` | The Checkly CLI configuration file. If not passed, uses the `checkly.config.ts|js` file in the current directory. |
-| `--root` | The root folder in which to write generated code files. |
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--config, -c` | - | The Checkly CLI configuration file. If not passed, uses the `checkly.config.ts|js` file in the current directory. |
+| `--root` | - | The root folder in which to write generated code files. |
 
 ## Command Options
 

--- a/cli/checkly-incidents.mdx
+++ b/cli/checkly-incidents.mdx
@@ -362,7 +362,7 @@ npx checkly incidents resolve <id> [options]
 
 | Argument | Description |
 |----------|-------------|
-| `ID` | The ID of the incident to resolve. |
+| `id` | The ID of the incident to resolve. |
 
 **Options:**
 

--- a/cli/checkly-logout.mdx
+++ b/cli/checkly-logout.mdx
@@ -23,9 +23,9 @@ The basic command logs out of your current Checkly account and removes stored au
 npx checkly logout [options]
 ```
 
-| Option | Description |
-|--------|-------------|
-| `--force, -f` | Force mode. Skips the confirmation dialog. |
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--force, -f` | - | Force mode. Skips the confirmation dialog. |
 
 ## Command Options
 

--- a/cli/checkly-pw-test.mdx
+++ b/cli/checkly-pw-test.mdx
@@ -32,32 +32,32 @@ npx checkly pw-test [checkly options] -- [playwright options]
 
 Define `checkly pw-test` specific options before the `--` separator:
 
-| Option | Description |
-|--------|-------------|
-| `--config` | The Checkly CLI configuration file. If not passed, uses the `checkly.config.ts\|js` file in the current directory. |
-| `--create-check` | Create a Checkly check from the Playwright test. |
-| `--env, -e` | Env vars to be passed to the test run. Default: [] |
-| `--env-file` | dotenv file path to be passed. For example `--env-file="./.env"` |
-| `--installCommand` | Override the command used to install dependencies before running tests. |
-| `--location, -l` | The location to run the checks at. |
-| `--private-location` | The private location to run checks at. |
-| `--[no-]record` | Record test results in Checkly as a test session with full logs, traces and videos. |
-| `--reporter` | A list of custom reporters for the test output. |
-| `--stream-logs` | Stream logs from the test run to the console. |
-| `--test-session-name` | A name to use when storing results in Checkly |
-| `--timeout` | A timeout (in seconds) to wait for checks to complete. |
-| `--verbose` | Always show the full logs of the checks. |
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--config` | - | The Checkly CLI configuration file. If not passed, uses the `checkly.config.ts\|js` file in the current directory. |
+| `--create-check` | - | Create a Checkly check from the Playwright test. |
+| `--env, -e` | - | Env vars to be passed to the test run. Default: [] |
+| `--env-file` | - | dotenv file path to be passed. For example `--env-file="./.env"` |
+| `--installCommand` | - | Override the command used to install dependencies before running tests. |
+| `--location, -l` | - | The location to run the checks at. |
+| `--private-location` | - | The private location to run checks at. |
+| `--[no-]record` | - | Record test results in Checkly as a test session with full logs, traces and videos. |
+| `--reporter` | - | A list of custom reporters for the test output. |
+| `--stream-logs` | - | Stream logs from the test run to the console. |
+| `--test-session-name` | - | A name to use when storing results in Checkly |
+| `--timeout` | - | A timeout (in seconds) to wait for checks to complete. |
+| `--verbose` | - | Always show the full logs of the checks. |
 
 </Tab>
 <Tab title="Playwright Test Options">
 
 Define Playwright test runner flags after the `--` separator:
 
-| Option | Description |
-|------|-------------|
-| `--project` | Select Playwright projects |
-| `--grep` | Filter tests by pattern |
-| `--grep-invert` | Exclude tests by pattern |
+| Option | Required | Description |
+|------|----------|-------------|
+| `--project` | - | Select Playwright projects |
+| `--grep` | - | Filter tests by pattern |
+| `--grep-invert` | - | Exclude tests by pattern |
 
 <Tip>The `--reporter` and `--headed` options are not supported. Find more Playwright options in the [Playwright test runner docs](https://playwright.dev/docs/test-cli).</Tip>
 
@@ -123,7 +123,7 @@ const config = defineConfig({
 
 </ResponseField>
 
-<ResponseField name="--env, -e">
+<ResponseField name="--env, -e" type="string[]">
 
 Pass environment variables to the test run. Can be specified multiple times to set multiple variables.
 

--- a/cli/checkly-status-pages.mdx
+++ b/cli/checkly-status-pages.mdx
@@ -42,12 +42,12 @@ npx checkly status-pages list [options]
 
 **Options:**
 
-| Option | Description |
-|--------|-------------|
-| `--limit, -l` | Number of status pages to return (1-100). Default: `25`. |
-| `--cursor` | Cursor for next page (from previous output). |
-| `--compact` | Show one row per status page instead of per service. |
-| `--output, -o` | Output format: `table`, `json`, or `md`. Default: `table`. |
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--limit, -l` | - | Number of status pages to return (1-100). Default: `25`. |
+| `--cursor` | - | Cursor for next page (from previous output). |
+| `--compact` | - | Show one row per status page instead of per service. |
+| `--output, -o` | - | Output format: `table`, `json`, or `md`. Default: `table`. |
 
 ### List Options
 
@@ -131,13 +131,13 @@ npx checkly status-pages get <id> [options]
 
 | Argument | Description |
 |----------|-------------|
-| `ID` | The ID of the status page to retrieve. |
+| `id` | The ID of the status page to retrieve. |
 
 **Options:**
 
-| Option | Description |
-|--------|-------------|
-| `--output, -o` | Output format: `detail`, `json`, or `md`. Default: `detail`. |
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--output, -o` | - | Output format: `detail`, `json`, or `md`. Default: `detail`. |
 
 ### Get Options
 

--- a/cli/checkly-switch.mdx
+++ b/cli/checkly-switch.mdx
@@ -23,9 +23,9 @@ The basic command displays available accounts and provides an interactive select
 npx checkly switch [options]
 ```
 
-| Option | Description |
-|--------|-------------|
-| `--account-id, -a` | The id of the account you want to switch to. |
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--account-id, -a` | - | The id of the account you want to switch to. |
 
 
 ## Command Options

--- a/cli/checkly-test.mdx
+++ b/cli/checkly-test.mdx
@@ -18,28 +18,28 @@ The basic command runs all checks in your project as a test run without deployin
 npx checkly test [arguments] [options]
 ```
 
-| Option | Description |
-|--------|-------------|
-| `--config, -c` | The Checkly CLI configuration file. If not passed, uses the `checkly.config.ts\|js` file in the current directory. |
-| `--env, -e` | Env vars to be passed to the test run. Can be used multiple times. |
-| `--env-file` | dotenv file path to be passed. For example `--env-file="./.env"` |
-| `--grep, -g` | Only run checks where the check name matches a regular expression. Default: `.*` |
-| `--list` | List all checks but don't run them. |
-| `--location, -l` | The location to run the checks at. |
-| `--private-location` | The private location to run checks at. |
-| `--record` | Record test results in Checkly as a test session with full logs, traces and videos. |
-| `--reporter, -r` | A list of custom reporters for the test output. |
-| `--retries` | How many times to retry a failing test run. |
-| `--tags, -t` | Filter the checks to be run using a comma separated list of tags. |
-| `--test-session-name, -n` | A name to use when storing results in Checkly with `--record`. |
-| `--timeout` | A timeout (in seconds) to wait for checks to complete. |
-| `--update-snapshots, -u` | Update any snapshots using the actual result of this test run. |
-| `--verbose, -v` | Always show the full logs of the checks. |
-| `--[no-]verify-runtime-dependencies` | Return an error if checks import dependencies that are not supported by the selected runtime. |
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--config, -c` | - | The Checkly CLI configuration file. If not passed, uses the `checkly.config.ts\|js` file in the current directory. |
+| `--env, -e` | - | Env vars to be passed to the test run. Can be used multiple times. |
+| `--env-file` | - | dotenv file path to be passed. For example `--env-file="./.env"` |
+| `--grep, -g` | - | Only run checks where the check name matches a regular expression. Default: `.*` |
+| `--list` | - | List all checks but don't run them. |
+| `--location, -l` | - | The location to run the checks at. |
+| `--private-location` | - | The private location to run checks at. |
+| `--record` | - | Record test results in Checkly as a test session with full logs, traces and videos. |
+| `--reporter, -r` | - | A list of custom reporters for the test output. |
+| `--retries` | - | How many times to retry a failing test run. |
+| `--tags, -t` | - | Filter the checks to be run using a comma separated list of tags. |
+| `--test-session-name, -n` | - | A name to use when storing results in Checkly with `--record`. |
+| `--timeout` | - | A timeout (in seconds) to wait for checks to complete. |
+| `--update-snapshots, -u` | - | Update any snapshots using the actual result of this test run. |
+| `--verbose, -v` | - | Always show the full logs of the checks. |
+| `--[no-]verify-runtime-dependencies` | - | Return an error if checks import dependencies that are not supported by the selected runtime. |
 
 ## Command Options
 
-<ResponseField name="--config" type="string">
+<ResponseField name="--config, -c" type="string">
 
 The Checkly CLI configuration file. If not passed, uses the `checkly.config.ts|js` file in the current directory.
 
@@ -52,7 +52,7 @@ npx checkly test -c="./checkly.staging.config.ts"
 
 </ResponseField>
 
-<ResponseField name="--env" type="string[]">
+<ResponseField name="--env, -e" type="string[]">
 
 [Environment variables](/cli/environment-variables) to be passed to the test run. Can be used multiple times.
 
@@ -87,7 +87,7 @@ npx checkly test --env-file="./config/.env.production"
 
 </ResponseField>
 
-<ResponseField name="--grep" type="string">
+<ResponseField name="--grep, -g" type="string">
 
 Only run checks where the check name matches a regular expression. Default: `.*`
 
@@ -100,7 +100,7 @@ npx checkly test -g="^production-.*"
 
 </ResponseField>
 
-<ResponseField name="--location" type="string">
+<ResponseField name="--location, -l" type="string">
 
 The location to run the checks at.
 
@@ -138,7 +138,7 @@ npx checkly test --private-location="office-network" --config="./checkly.office.
 
 </ResponseField>
 
-<ResponseField name="--tags" type="string[]">
+<ResponseField name="--tags, -t" type="string[]">
 
 Filter the checks to be run using a comma separated list of tags. Checks will only be run if they contain all of the specified tags. Multiple `--tags` flags can be passed, in which case checks will be run if they match any of the `--tags` filters.
 
@@ -184,7 +184,7 @@ npx checkly test --list --tags="production"
 
 </ResponseField>
 
-<ResponseField name="--reporter" type="string">
+<ResponseField name="--reporter, -r" type="string">
 
 A list of custom reporters for the test output. Options: `list|dot|ci|github|json`
 
@@ -254,7 +254,7 @@ npx checkly test --retries 3
 
 </ResponseField>
 
-<ResponseField name="--test-session-name" type="string">
+<ResponseField name="--test-session-name, -n" type="string">
 
 A name to use when storing results in Checkly with `--record`.
 
@@ -279,7 +279,7 @@ npx checkly test --timeout=300
 
 </ResponseField>
 
-<ResponseField name="--update-snapshots" type="boolean">
+<ResponseField name="--update-snapshots, -u" type="boolean">
 
 Update any snapshots using the actual result of this test run.
 
@@ -294,7 +294,7 @@ npx checkly test -u
 
 </ResponseField>
 
-<ResponseField name="--verbose" type="boolean">
+<ResponseField name="--verbose, -v" type="boolean">
 
 Always show the full logs of the checks.
 

--- a/cli/checkly-trigger.mdx
+++ b/cli/checkly-trigger.mdx
@@ -18,25 +18,25 @@ The basic command triggers all checks in your account that are already deployed.
 npx checkly trigger [options]
 ```
 
-| Option | Description |
-|--------|-------------|
-| `--config, -c` | The Checkly CLI configuration file. If not passed, uses the `checkly.config.ts\|js` file in the current directory. |
-| `--env, -e` | Env vars to be passed to the check run. Default: empty. Multiple values can be passed. |
-| `--env-file` | dotenv file path to be passed. For example `--env-file="./.env"` |
-| `--fail-on-no-matching` | Exit with a failing status code when there are no matching tests. |
-| `--location, -l` | The location to run the checks at. |
-| `--private-location` | The private location to run checks at. |
-| `--record` | Record check results in Checkly as a test session with full logs, traces and videos. |
-| `--reporter, -r` | A list of custom reporters for the test output. |
-| `--retries` | How many times to retry a check run. |
-| `--tags, -t` | Filter the checks to be run using a comma separated list of tags. |
-| `--test-session-name, -n` | A name to use when storing results in Checkly with `--record`. |
-| `--timeout` | A timeout (in seconds) to wait for checks to complete. |
-| `--verbose, -v` | Always show the full logs of the checks. |
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--config, -c` | - | The Checkly CLI configuration file. If not passed, uses the `checkly.config.ts\|js` file in the current directory. |
+| `--env, -e` | - | Env vars to be passed to the check run. Default: empty. Multiple values can be passed. |
+| `--env-file` | - | dotenv file path to be passed. For example `--env-file="./.env"` |
+| `--fail-on-no-matching` | - | Exit with a failing status code when there are no matching tests. |
+| `--location, -l` | - | The location to run the checks at. |
+| `--private-location` | - | The private location to run checks at. |
+| `--record` | - | Record check results in Checkly as a test session with full logs, traces and videos. |
+| `--reporter, -r` | - | A list of custom reporters for the test output. |
+| `--retries` | - | How many times to retry a check run. |
+| `--tags, -t` | - | Filter the checks to be run using a comma separated list of tags. |
+| `--test-session-name, -n` | - | A name to use when storing results in Checkly with `--record`. |
+| `--timeout` | - | A timeout (in seconds) to wait for checks to complete. |
+| `--verbose, -v` | - | Always show the full logs of the checks. |
 
 ## Command Options
 
-<ResponseField name="--config" type="string" alias="-c">
+<ResponseField name="--config, -c" type="string">
 
 Specify a configuration file to use instead of the `checkly.config.ts` or `checkly.config.js` in the current directory.
 
@@ -49,7 +49,7 @@ npx checkly trigger -c="./checkly.staging.config.ts"
 
 </ResponseField>
 
-<ResponseField name="--env">
+<ResponseField name="--env, -e" type="string[]">
 
 [Environment variables](/cli/environment-variables) to be passed to the check run. Multiple values can be passed and passed variables overwrite any existing variables stored in your Checkly account.
 
@@ -99,7 +99,7 @@ The dotenv file should contain KEY=value pairs, one per line.
 
 </ResponseField>
 
-<ResponseField name="--location" type="string" alias="-l">
+<ResponseField name="--location, -l" type="string">
 The location to run the checks at.
 
 **Usage:**
@@ -138,7 +138,7 @@ npx checkly trigger --private-location"vpc-location" --config="internal.config.j
 Private locations must be configured in your Checkly account before use.
 </ResponseField>
 
-<ResponseField name="--tags">
+<ResponseField name="--tags, -t" type="string[]">
 Filter checks using tags. Checks run if they contain all specified tags in a single --tags flag. Multiple --tags flags create OR conditions.
 
 **Usage:**
@@ -165,7 +165,7 @@ npx checkly trigger --tags="production,webapp" --tags="production,backend"
 Tags are comma-separated within a single flag for AND logic, multiple flags for OR logic.
 </ResponseField>
 
-<ResponseField name="--test-session-name" type="string" >
+<ResponseField name="--test-session-name, -n" type="string">
 
 A name to use when storing results in Checkly with `--record`.
 
@@ -177,7 +177,7 @@ npx checkly trigger --record --test-session-name="Custom session name"
 
 </ResponseField>
 
-<ResponseField name="--reporter" type="string">
+<ResponseField name="--reporter, -r" type="string">
 
 Custom reporters for test output formatting.
 
@@ -210,7 +210,7 @@ npx checkly trigger --reporter json > results.json
 Available options: `list`, `dot`, `ci`, `github`, `json`. Each provides different output formatting.
 </ResponseField>
 
-<ResponseField name="--verbose" type="boolean">
+<ResponseField name="--verbose, -v" type="boolean">
 
 Always show the full logs of the checks.
 

--- a/cli/checkly-whoami.mdx
+++ b/cli/checkly-whoami.mdx
@@ -41,3 +41,5 @@ environment variables to setup authentication.
 ## Related Commands
 
 - [`checkly login`](/cli/checkly-login) - Sign in to your Checkly account
+- [`checkly logout`](/cli/checkly-logout) - Sign out of your Checkly account
+- [`checkly switch`](/cli/checkly-switch) - Switch between multiple accounts


### PR DESCRIPTION
## Summary

- Add **Required** column to all options tables across all 13 CLI command pages (matching construct page pattern)
- Standardize argument names to lowercase (`ID` → `id`) in argument tables
- Fix ResponseField short flag pattern to consistently use `name="--flag, -f"` (removes `alias` attribute usage)
- Add missing `type` attributes to ResponseFields in `checkly-trigger` and `checkly-pw-test`
- Add missing related commands to `checkly-whoami`

Addresses review feedback from #202.

## Test plan

- [ ] Spot-check options tables render with the Required column
- [ ] Verify ResponseField components display correctly
- [ ] Confirm no broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)