### PR TITLE
doc: CLI checks stats and analytics flags

### DIFF
--- a/cli/checkly-checks.mdx
+++ b/cli/checkly-checks.mdx
@@ -1,12 +1,12 @@
 ---
 title: checkly checks
-description: 'List and inspect checks in your Checkly account.'
+description: 'List, inspect, and analyze checks in your Checkly account.'
 sidebarTitle: 'checkly checks'
 ---
 
-<Note>Available since CLI v7.3.0.</Note>
+<Note>Available since CLI v7.3.0. Analytics stats available since v7.6.0.</Note>
 
-The `checkly checks` command lets you list and inspect checks in your Checkly account directly from the terminal. You can filter, search, and drill into individual check details, recent results, and error groups.
+The `checkly checks` command lets you list, inspect, and analyze checks in your Checkly account directly from the terminal. You can filter, search, and drill into individual check details, recent results, error groups, and analytics stats.
 
 <Accordion title="Prerequisites">
 Before using `checkly checks`, ensure you have:
@@ -28,7 +28,8 @@ npx checkly checks <subcommand> [arguments] [options]
 | Subcommand | Description |
 |------------|-------------|
 | `list` | List all checks in your account. |
-| `get` | Get details of a specific check, including recent results. |
+| `get` | Get details of a specific check, including recent results and analytics stats. |
+| `stats` | Show analytics stats for your checks. |
 
 ## `checkly checks list`
 
@@ -165,7 +166,7 @@ npx checkly checks list --limit=10 --page=2
 
 ## `checkly checks get`
 
-Get details of a specific check, including recent results. Use `--result` to drill into a specific result or `--error-group` to view error details.
+Get details of a specific check, including recent results and analytics stats. Use `--result` to drill into a specific result, `--error-group` to view error details, or the stats flags to customize the analytics view.
 
 **Usage:**
 
@@ -187,6 +188,10 @@ npx checkly checks get <id> [options]
 | `--error-group, -e` | - | Show full details for a specific error group ID. |
 | `--results-limit` | - | Number of recent results to show. Default: `10`. |
 | `--results-cursor` | - | Cursor for results pagination (from previous output). |
+| `--stats-range` | - | Time range for stats: `last24Hours`, `last7Days`, `last30Days`, `thisWeek`, `thisMonth`, `lastWeek`, `lastMonth`. Default: `last24Hours`. |
+| `--group-by` | - | Group stats by dimension: `location` or `statusCode`. |
+| `--metrics` | - | Comma-separated list of metrics to show (overrides defaults). |
+| `--filter-status` | - | Only include runs with this status in stats: `success` or `failure`. |
 | `--output, -o` | - | Output format: `detail`, `json`, or `md`. Default: `detail`. |
 
 ### Get Options
@@ -241,6 +246,88 @@ npx checkly checks get <check-id> --results-cursor=<cursor>
 
 </ResponseField>
 
+<ResponseField name="--stats-range" type="string" default="last24Hours">
+
+Time range for the analytics stats section. Available ranges: `last24Hours`, `last7Days`, `last30Days`, `thisWeek`, `thisMonth`, `lastWeek`, `lastMonth`.
+
+**Usage:**
+
+```bash Terminal
+npx checkly checks get <check-id> --stats-range=last7Days
+```
+
+</ResponseField>
+
+<ResponseField name="--group-by" type="string">
+
+Group analytics stats by a specific dimension. Use `location` to break down metrics by geographic region, or `statusCode` to group by HTTP status code.
+
+**Usage:**
+
+```bash Terminal
+npx checkly checks get <check-id> --group-by=location
+npx checkly checks get <check-id> --group-by=statusCode
+```
+
+</ResponseField>
+
+<ResponseField name="--metrics" type="string">
+
+Comma-separated list of metrics to display, overriding the defaults. When omitted, a sensible set of defaults is used based on the check type. You can also retrieve the full list of available metrics from the [List all available reporting metrics](/api-reference/analytics/list-all-available-reporting-metrics) API endpoint.
+
+**Available metrics by check type:**
+
+| Metric | Applies to | Unit |
+|--------|-----------|------|
+| `availability` | All check types | % |
+| `responseTime_avg` | API, Browser, Playwright, Multi-Step, URL | ms |
+| `responseTime_p50` | API, Browser, Playwright, Multi-Step, URL | ms |
+| `responseTime_p95` | API, Browser, Playwright, Multi-Step, URL | ms |
+| `responseTime_p99` | API, Browser, Playwright, Multi-Step, URL | ms |
+| `total_avg` | TCP, DNS | ms |
+| `total_p50` | TCP, DNS | ms |
+| `total_p95` | TCP, DNS | ms |
+| `total_p99` | TCP, DNS | ms |
+| `latencyAvg_avg` | ICMP | ms |
+| `latencyAvg_p50` | ICMP | ms |
+| `latencyAvg_p95` | ICMP | ms |
+| `latencyAvg_p99` | ICMP | ms |
+| `packetLoss_avg` | ICMP | % |
+| `LCP_avg` | Browser, Playwright | ms |
+| `CLS_avg` | Browser, Playwright | score |
+| `TBT_avg` | Browser, Playwright | ms |
+
+**Default metrics per check type:**
+
+| Check type | Default metrics |
+|------------|----------------|
+| API, Multi-Step, URL | `availability`, `responseTime_avg`, `responseTime_p50`, `responseTime_p95`, `responseTime_p99` |
+| Browser, Playwright | `availability`, `LCP_avg`, `CLS_avg`, `TBT_avg`, `responseTime_avg`, `responseTime_p95` |
+| TCP, DNS | `availability`, `total_avg`, `total_p50`, `total_p95`, `total_p99` |
+| ICMP | `availability`, `packetLoss_avg`, `latencyAvg_avg`, `latencyAvg_p50`, `latencyAvg_p95`, `latencyAvg_p99` |
+| Heartbeat | `availability` |
+
+**Usage:**
+
+```bash Terminal
+npx checkly checks get <check-id> --metrics=availability,responseTime_avg,responseTime_p95
+```
+
+</ResponseField>
+
+<ResponseField name="--filter-status" type="string">
+
+Only include runs with a specific status in the analytics stats. Use `success` to see stats for passing runs only, or `failure` for failing runs.
+
+**Usage:**
+
+```bash Terminal
+npx checkly checks get <check-id> --filter-status=failure
+npx checkly checks get <check-id> --filter-status=success
+```
+
+</ResponseField>
+
 <ResponseField name="--output, -o" type="string" default="detail">
 
 Set the output format. Use `json` for programmatic access or `md` for markdown.
@@ -257,8 +344,20 @@ npx checkly checks get <check-id> -o md
 ### Get Examples
 
 ```bash Terminal
-# View check details and recent results
+# View check details, recent results, and stats
 npx checkly checks get 12345
+
+# View stats for the last 7 days
+npx checkly checks get 12345 --stats-range=last7Days
+
+# Break down stats by location
+npx checkly checks get 12345 --group-by=location
+
+# Show only specific metrics
+npx checkly checks get 12345 --metrics=availability,responseTime_avg,responseTime_p95
+
+# Show stats for failed runs only
+npx checkly checks get 12345 --filter-status=failure
 
 # Drill into a specific result
 npx checkly checks get 12345 --result=abc-123
@@ -271,6 +370,149 @@ npx checkly checks get 12345 --output=json
 
 # Show more results
 npx checkly checks get 12345 --results-limit=25
+```
+
+## `checkly checks stats`
+
+Show analytics stats for your checks. View availability, response times, and other metrics across multiple checks at once, with filtering by tag, type, or name.
+
+**Usage:**
+
+```bash Terminal
+npx checkly checks stats [checkIds...] [options]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `checkIds` | One or more check IDs to get stats for. If omitted, stats are shown for all checks. |
+
+**Options:**
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--range, -r` | - | Time range for stats: `last24Hours`, `last7Days`, `thisWeek`, `lastWeek`, `lastMonth`. Default: `last24Hours`. |
+| `--limit, -l` | - | Number of checks to return (1-100). Default: `25`. |
+| `--page, -p` | - | Page number. Default: `1`. |
+| `--search, -s` | - | Filter checks by name (case-insensitive). |
+| `--tag, -t` | - | Filter by tag. Can be specified multiple times. |
+| `--type` | - | Filter by check type. |
+| `--output, -o` | - | Output format: `table`, `json`, or `md`. Default: `table`. |
+
+### Stats Options
+
+<ResponseField name="--range, -r" type="string" default="last24Hours">
+
+Time range for the analytics stats. Available ranges: `last24Hours`, `last7Days`, `thisWeek`, `lastWeek`, `lastMonth`.
+
+**Usage:**
+
+```bash Terminal
+npx checkly checks stats --range=last7Days
+npx checkly checks stats -r lastMonth
+```
+
+</ResponseField>
+
+<ResponseField name="--limit, -l" type="number" default="25">
+
+Number of checks to return per page, between 1 and 100.
+
+**Usage:**
+
+```bash Terminal
+npx checkly checks stats --limit=50
+npx checkly checks stats -l 10
+```
+
+</ResponseField>
+
+<ResponseField name="--page, -p" type="number" default="1">
+
+Page number for paginated results.
+
+**Usage:**
+
+```bash Terminal
+npx checkly checks stats --page=2
+npx checkly checks stats -p 3
+```
+
+</ResponseField>
+
+<ResponseField name="--search, -s" type="string">
+
+Filter checks by name using a case-insensitive search.
+
+**Usage:**
+
+```bash Terminal
+npx checkly checks stats --search="homepage"
+npx checkly checks stats -s "api"
+```
+
+</ResponseField>
+
+<ResponseField name="--tag, -t" type="string">
+
+Filter checks by tag. Specify multiple times to filter by multiple tags.
+
+**Usage:**
+
+```bash Terminal
+npx checkly checks stats --tag=production
+npx checkly checks stats -t production -t critical
+```
+
+</ResponseField>
+
+<ResponseField name="--type" type="string">
+
+Filter checks by type. Available types: `API`, `BROWSER`, `MULTI_STEP`, `HEARTBEAT`, `PLAYWRIGHT`, `TCP`, `DNS`, `ICMP`, `URL`.
+
+**Usage:**
+
+```bash Terminal
+npx checkly checks stats --type=API
+npx checkly checks stats --type=BROWSER
+```
+
+</ResponseField>
+
+<ResponseField name="--output, -o" type="string" default="table">
+
+Set the output format. Use `json` for programmatic access or `md` for markdown.
+
+**Usage:**
+
+```bash Terminal
+npx checkly checks stats --output=json
+npx checkly checks stats -o md
+```
+
+</ResponseField>
+
+### Stats Examples
+
+```bash Terminal
+# Show stats for all checks (last 24 hours)
+npx checkly checks stats
+
+# Show stats for specific checks
+npx checkly checks stats 12345 67890
+
+# Show stats for the last 7 days
+npx checkly checks stats --range=last7Days
+
+# Filter by tag and type
+npx checkly checks stats --tag=production --type=API
+
+# Search by name and output as JSON
+npx checkly checks stats --search="homepage" --output=json
+
+# Page through results
+npx checkly checks stats --limit=10 --page=2
 ```
 
 ## Related Commands


### PR DESCRIPTION
## Summary
- Documents the new `checkly checks stats` subcommand (CLI v7.6.0) for viewing analytics across multiple checks
- Adds analytics flags (`--stats-range`, `--group-by`, `--metrics`, `--filter-status`) to `checks get` documentation
- Includes full metrics reference tables by check type with defaults and units

## Test plan
- [ ] Verify page renders correctly in Mintlify preview
- [ ] Confirm all flag names and options match CLI `--help` output
- [ ] Check internal link to analytics metrics API endpoint works

🤖 Generated with [Claude Code](https://claude.com/claude-code)