### PR TITLE
docs: add incident duration calculation and custom date sections

### DIFF
--- a/communicate/status-pages/incidents.mdx
+++ b/communicate/status-pages/incidents.mdx
@@ -52,14 +52,7 @@ Incident duration measures the actual downtime of your service. It is calculated
 
 For example, if an incident was opened at 10:00, resolved at 10:30, then re-opened at 11:00 and resolved again at 11:30, the duration would be 1 hour 30 minutes (10:00 → 11:30). However, if the incident was resolved at 10:30 and a second resolved update was added later without re-opening, the duration remains 30 minutes.
 
-### Adjusting incident duration with custom dates
-
-Each incident update has a public date that determines when the update is considered to have occurred. You can edit this date to adjust the incident timeline and duration. This is useful when:
-
-- You need to correct the start time of an incident that was reported late.
-- You want to set an accurate resolved time for an incident that was resolved before the update was posted.
-
-To change an update's public date, edit the incident update and select a custom date and time.
+You can adjust the incident duration by editing the public date on incident updates, or by [backfilling an incident](/communicate/status-pages/incidents#backfilling-an-incident) with custom timestamps.
 
 ## Incident notifications
 


### PR DESCRIPTION
## Summary

- Added "Incident duration" section explaining how duration is calculated (first update → first resolved update that closed the incident, with re-open/re-resolve logic)
- Added "Adjusting incident duration with custom dates" subsection explaining how editing the public date on updates affects the duration

<img width="781" height="518" alt="image" src="https://github.com/user-attachments/assets/31060bb6-558f-476e-ab40-395b730882f3" />


Related: https://github.com/checkly/monorepo/pull/950