### PR TITLE
Add docs for skills manage, skills install, and account plan

### DIFF
--- a/cli/checkly-account.mdx
+++ b/cli/checkly-account.mdx
@@ -1,0 +1,194 @@
+---
+title: checkly account
+description: 'View your Checkly account plan, entitlements, and feature limits.'
+sidebarTitle: 'checkly account'
+---
+
+<Note>Available since CLI v7.7.0.</Note>
+
+The `checkly account` command lets you view your account plan, entitlements, and feature limits directly from the terminal. Use it to check which features are available on your plan, inspect metered limits, and discover available check locations.
+
+<Accordion title="Prerequisites">
+Before using `checkly account`, ensure you have:
+
+- Checkly CLI installed
+- Valid Checkly account authentication (run `npx checkly login` if needed)
+
+For additional setup information, see [CLI overview](/cli/overview).
+</Accordion>
+
+## Usage
+
+```bash Terminal
+npx checkly account <subcommand> [arguments] [options]
+```
+
+## Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `plan` | Show your account plan, entitlements, and feature limits. |
+
+## `checkly account plan`
+
+Show your account plan, entitlements, and feature limits. The default view displays a summary of metered entitlements with their limits. Use `--output=json` for the full response including locations, feature flags, and upgrade URLs.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account plan [key] [options]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `key` | Entitlement key to look up (e.g. `BROWSER_CHECKS`). Shows a detail view for that entitlement. |
+
+**Options:**
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--type, -t` | - | Filter entitlements by type: `metered` or `flag`. |
+| `--search, -s` | - | Search entitlements by name or description. |
+| `--disabled` | - | Show only entitlements not included in your plan. |
+| `--output, -o` | - | Output format: `table`, `json`, or `md`. Default: `table`. |
+
+### Plan Options
+
+<ResponseField name="key" type="string">
+
+Pass an entitlement key as a positional argument to see a detail view for that specific entitlement, including its type, status, limit, and upgrade URL if applicable.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account plan BROWSER_CHECKS
+npx checkly account plan PRIVATE_LOCATIONS
+```
+
+</ResponseField>
+
+<ResponseField name="--type, -t" type="string">
+
+Filter entitlements by type. Use `metered` to see entitlements with numeric limits, or `flag` to see boolean feature flags.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account plan --type=metered
+npx checkly account plan -t flag
+```
+
+</ResponseField>
+
+<ResponseField name="--search, -s" type="string">
+
+Search entitlements by name or description using a case-insensitive match.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account plan --search="browser"
+npx checkly account plan -s "alert"
+```
+
+</ResponseField>
+
+<ResponseField name="--disabled" type="boolean">
+
+Show only entitlements that are not included in your current plan. Each disabled entitlement includes the required plan and an upgrade URL.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account plan --disabled
+npx checkly account plan --disabled --type=flag
+```
+
+</ResponseField>
+
+<ResponseField name="--output, -o" type="string" default="table">
+
+Set the output format. Use `json` for the full response including locations, all entitlements, and upgrade URLs. Use `md` for markdown.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account plan --output=json
+npx checkly account plan -o md
+```
+
+</ResponseField>
+
+### Plan Examples
+
+```bash Terminal
+# Show account plan summary (metered limits + flag count)
+npx checkly account plan
+
+# Get the full response as JSON (recommended for agents)
+npx checkly account plan --output=json
+
+# Show only metered entitlements
+npx checkly account plan --type=metered
+
+# Show only feature flags
+npx checkly account plan --type=flag
+
+# Search for specific entitlements
+npx checkly account plan --search="browser"
+
+# Show features not included in your plan
+npx checkly account plan --disabled
+
+# Look up a specific entitlement
+npx checkly account plan BROWSER_CHECKS
+```
+
+### JSON Response
+
+The `--output=json` format returns a structured response useful for programmatic access and AI agents.
+
+```json
+{
+  "plan": "hobby",
+  "planDisplayName": "Hobby",
+  "checkoutUrl": "https://app.checklyhq.com/accounts/.../billing/checkout",
+  "contactSalesUrl": "https://www.checklyhq.com/contact-sales/",
+  "locations": {
+    "all": [
+      { "id": "us-east-1", "name": "N. Virginia", "available": true },
+      { "id": "eu-west-1", "name": "Ireland", "available": false }
+    ],
+    "maxPerCheck": 3
+  },
+  "entitlements": [
+    {
+      "key": "BROWSER_CHECKS",
+      "type": "metered",
+      "enabled": true,
+      "quantity": 10
+    },
+    {
+      "key": "PRIVATE_LOCATIONS",
+      "type": "metered",
+      "enabled": false,
+      "requiredPlan": "TEAM",
+      "requiredPlanDisplayName": "Team",
+      "upgradeUrl": "https://app.checklyhq.com/accounts/.../billing/checkout"
+    }
+  ]
+}
+```
+
+Key fields:
+
+- **`locations.all`** — filter to entries where `available` is `true` to get valid locations for your checks. Respect `maxPerCheck` as the upper bound per check.
+- **`entitlements`** — metered entitlements include a `quantity` limit. Disabled entitlements include `requiredPlan` and `upgradeUrl`.
+
+## Related Commands
+
+- [`checkly skills manage`](/cli/checkly-skills#checkly-skills-manage-resource) - Account management context for AI agents
+- [`checkly whoami`](/cli/checkly-whoami) - Display current account information
+- [`checkly switch`](/cli/checkly-switch) - Switch between Checkly accounts

--- a/cli/checkly-skills.mdx
+++ b/cli/checkly-skills.mdx
@@ -27,16 +27,25 @@ npx checkly skills
 npx checkly skills <action> [resource]
 ```
 
-## Subcommands
+## Actions
 
-| Subcommand | Description |
-|------------|-------------|
+| Action | Description |
+|--------|-------------|
 | `initialize` | Let your agent initialize [a new Checkly project](/constructs/project). |
 | `configure` | Let your agent configure [Checkly constructs](/constructs/overview). |
+| `investigate` | Access check status, analyze failures, and investigate errors. |
+| `communicate` | Open incidents and lead customer communications via status pages. |
+| `manage` | Understand your account plan, entitlements, and feature limits. |
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `install` | Install the Checkly agent skill (SKILL.md) into your project. |
 
 ## `checkly skills initialize` (experimental)
 
-The `initialize` subcommand outputs LLM-optimized Markdown with all the context an agent needs to set up a new Checkly project from scratch. The context will instruct your agent to install required packages, create config files and scan your current project for resources to monitor.
+The `initialize` action outputs LLM-optimized Markdown with all the context an agent needs to set up a new Checkly project from scratch. The context will instruct your agent to install required packages, create config files and scan your current project for resources to monitor.
 
 **Usage:**
 
@@ -50,7 +59,7 @@ You can prompt your agent with **"run `npx checkly skills initialize` and follow
 
 ## `checkly skills configure [resource]`
 
-The `configure` subcommand is an umbrella command that provides Markdown context about all available Checkly resources. The CLI outputs everything your agent needs to configure [Checkly constructs](/constructs/overview) directly — no additional docs fetching or file reading required.
+The `configure` action is an umbrella command that provides Markdown context about all available Checkly resources. The CLI outputs everything your agent needs to configure [Checkly constructs](/constructs/overview) directly — no additional docs fetching or file reading required.
 
 Run `configure` without arguments to see all available resources, or pass a specific resource name to get targeted context.
 
@@ -62,3 +71,145 @@ npx checkly skills configure api-checks
 npx checkly skills configure browser-checks
 # ...and more
 ```
+
+## `checkly skills investigate [resource]`
+
+The `investigate` action provides context for inspecting check status, analyzing failures, and investigating errors across your Checkly account.
+
+Run `investigate` without arguments to see all available resources, or pass a specific resource name for targeted context.
+
+**Usage:**
+
+```bash Terminal
+npx checkly skills investigate
+npx checkly skills investigate checks
+```
+
+**Available resources:**
+
+| Resource | Description |
+|----------|-------------|
+| `checks` | Inspecting checks (`checks list`, `checks get`) and triggering on-demand runs. |
+
+## `checkly skills communicate [resource]`
+
+The `communicate` action provides context for managing incidents and customer communications through status pages. Write commands like `incidents create`, `incidents update`, and `incidents resolve` follow a confirmation protocol — the CLI returns a JSON envelope for agent review before execution.
+
+Run `communicate` without arguments to see all available resources, or pass a specific resource name for targeted context.
+
+**Usage:**
+
+```bash Terminal
+npx checkly skills communicate
+npx checkly skills communicate incidents
+```
+
+**Available resources:**
+
+| Resource | Description |
+|----------|-------------|
+| `incidents` | Incident lifecycle (`incidents create`, `update`, `resolve`, `list`) and status pages. |
+
+## `checkly skills manage [resource]`
+
+The `manage` action provides context about your account's plan, entitlements, and limits. Use this to understand what features and locations are available before configuring checks.
+
+Run `manage` without arguments to see all available resources, or pass a specific resource name for targeted context.
+
+**Usage:**
+
+```bash Terminal
+npx checkly skills manage
+npx checkly skills manage plan
+```
+
+**Available resources:**
+
+| Resource | Description |
+|----------|-------------|
+| `plan` | Check account plan, entitlements, feature limits, and available locations ([`account plan`](/cli/checkly-account)). |
+
+<Tip>
+The `manage plan` resource documents the [`checkly account plan`](/cli/checkly-account) command. Your agent can use the `account plan` command to query entitlements and available locations before writing check configurations.
+</Tip>
+
+## `checkly skills install`
+
+The `install` command installs the Checkly agent skill file (SKILL.md) into your project. This file lets your AI agent automatically discover and use the `checkly skills` command.
+
+**Usage:**
+
+```bash Terminal
+npx checkly skills install
+npx checkly skills install --target <platform>
+npx checkly skills install --path <directory>
+```
+
+**Options:**
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--target, -t` | - | Platform to install the skill for. |
+| `--path, -p` | - | Custom target directory to install the skill into. |
+| `--force, -f` | - | Overwrite existing SKILL.md without confirmation. |
+
+### Install Options
+
+<ResponseField name="--target, -t" type="string">
+
+The target platform determines where and how the skill file is installed. Available platforms: `amp`, `claude`, `cline`, `codex`, `continue`, `cursor`, `gemini-cli`, `github-copilot`, `goose`, `opencode`, `roo`, `windsurf`.
+
+**Usage:**
+
+```bash Terminal
+npx checkly skills install --target=claude
+npx checkly skills install -t cursor
+```
+
+</ResponseField>
+
+<ResponseField name="--path, -p" type="string">
+
+Custom target directory to install the skill file into. Use this when the default location for your platform does not match your project structure.
+
+**Usage:**
+
+```bash Terminal
+npx checkly skills install --path=./my-agent-config
+```
+
+</ResponseField>
+
+<ResponseField name="--force, -f" type="boolean">
+
+Overwrite an existing SKILL.md without asking for confirmation.
+
+**Usage:**
+
+```bash Terminal
+npx checkly skills install --force
+```
+
+</ResponseField>
+
+### Install Examples
+
+```bash Terminal
+# Install for Claude Code
+npx checkly skills install --target=claude
+
+# Install for Cursor
+npx checkly skills install --target=cursor
+
+# Install to a custom directory
+npx checkly skills install --path=./agents
+
+# Overwrite an existing skill file
+npx checkly skills install --target=claude --force
+```
+
+## Related Commands
+
+- [`checkly account`](/cli/checkly-account) - View and manage your Checkly account
+- [`checkly checks`](/cli/checkly-checks) - List, inspect, and analyze checks
+- [`checkly incidents`](/cli/checkly-incidents) - Create, update, and resolve incidents

--- a/docs.json
+++ b/docs.json
@@ -534,6 +534,7 @@
           {
             "group": "CLI Commands",
             "pages": [
+              "cli/checkly-account",
               "cli/checkly-checks",
               "cli/checkly-deploy",
               "cli/checkly-destroy",


### PR DESCRIPTION
## Summary
- **New page: `checkly account`** — Documents the `account plan` subcommand with all options (`--type`, `--search`, `--disabled`, `--output`), positional `key` argument, examples, and JSON response shape
- **Expanded: `checkly skills`** — Added the `investigate`, `communicate`, and `manage` actions, plus full documentation for the `skills install` command with `--target`, `--path`, and `--force` options
- **Navigation:** Added `cli/checkly-account` to the CLI Commands group in `docs.json`

## Test plan
- [ ] Verify `checkly account` page renders correctly in Mintlify preview
- [ ] Verify updated `checkly skills` page renders correctly
- [ ] Check all internal links resolve (`/cli/checkly-account`, `/cli/checkly-skills`, etc.)
- [ ] Confirm sidebar navigation shows `checkly account` in alphabetical order

🤖 Generated with [Claude Code](https://claude.com/claude-code)