### PR TITLE
preserve resources docs

### DIFF
--- a/cli/checkly-destroy.mdx
+++ b/cli/checkly-destroy.mdx
@@ -26,6 +26,7 @@ npx checkly destroy [options]
 |--------|----------|-------------|
 | `--config, -c` | - | The Checkly CLI configuration file. If not passed, uses the `checkly.config.ts\|js` file in the current directory. |
 | `--force, -f` | - | Force mode. Skips the confirmation dialog. |
+| `--preserve-resources` | - | Delete the project but keep its resources in your account, unbound from any project. |
 
 ## Command Options
 
@@ -60,6 +61,17 @@ npx checkly destroy -f
 ```
 
 <Warning>Use with extreme caution as this command option bypasses safety prompts.</Warning>
+</ResponseField>
+
+<ResponseField name="--preserve-resources" type="boolean">
+Delete the project but keep its resources (checks, groups, alert channels, etc.) in your Checkly account. The resources become unbound from the project and can be imported into another project later.
+
+**Usage:**
+
+```bash Terminal
+npx checkly destroy --preserve-resources
+```
+
 </ResponseField>
 
 ## What Gets Destroyed


### PR DESCRIPTION
Documenting the following feature:

> When destroying a project (npx checkly destroy) we have so far deleted all project resources (checks, groups, etc.) along with the project. There's now a --preserve-resources option which allows one to delete the project while leaving the resources around. After this is done the resources are not bound to any project and are essentially equivalent to "UI-only" resources.
> This also introduces a way to undo npx checkly import. Previously, after finishing the import process, it was not possible to re-import the same resources again because they were already a part of the project you imported them to. By deleting the project with --preserve-resources, it is now possible to make the resources UI-only resources again, which allows them to be imported again.
