### PR TITLE
docs: document --preserve-resources flag for checkly destroy

### DIFF
--- a/cli/checkly-destroy.mdx
+++ b/cli/checkly-destroy.mdx
@@ -26,6 +26,7 @@ npx checkly destroy [options]
 |--------|----------|-------------|
 | `--config, -c` | - | The Checkly CLI configuration file. If not passed, uses the `checkly.config.ts\|js` file in the current directory. |
 | `--force, -f` | - | Force mode. Skips the confirmation dialog. |
+| `--preserve-resources` | - | Delete only the project, detaching its resources so they remain in your Checkly account. |
 
 ## Command Options
 
@@ -62,6 +63,26 @@ npx checkly destroy -f
 <Warning>Use with extreme caution as this command option bypasses safety prompts.</Warning>
 </ResponseField>
 
+<ResponseField name="--preserve-resources" type="boolean">
+
+Delete the project but preserve all of its resources (checks, groups, alert channels, dashboards, etc.) in your Checkly account. The resources are detached from the CLI project and become regular account-level resources that are no longer managed by the CLI.
+
+Use this when you want to stop managing resources as code but keep them running in your account.
+
+**Usage:**
+
+```bash Terminal
+npx checkly destroy --preserve-resources
+```
+
+**Examples:**
+
+```bash Terminal
+$ npx checkly destroy --preserve-resources --force
+```
+
+</ResponseField>
+
 ## What Gets Destroyed
 
 The `destroy` command removes the all the resources managed by the specified project. These resources could include:
@@ -72,6 +93,8 @@ The `destroy` command removes the all the resources managed by the specified pro
 - **Alert Channels** defined in your project
 - **Maintenance Windows** created via CLI
 - **Private Locations** (if managed by the project)
+
+When run with `--preserve-resources`, only the project itself is deleted. All of the above resources remain in your Checkly account as regular account-level resources and are no longer tracked by the CLI.
 
 ## Safety Considerations
 

--- a/cli/checkly-destroy.mdx
+++ b/cli/checkly-destroy.mdx
@@ -65,6 +65,8 @@ npx checkly destroy -f
 
 <ResponseField name="--preserve-resources" type="boolean">
 
+<Note>Available since CLI version `7.10.0`.</Note>
+
 Delete the project but preserve all of its resources (checks, groups, alert channels, dashboards, etc.) in your Checkly account. The resources are detached from the CLI project and become regular account-level resources that are no longer managed by the CLI.
 
 Use this when you want to stop managing resources as code but keep them running in your account.


### PR DESCRIPTION
## Summary
- Documents the new `--preserve-resources` flag for `checkly destroy`, which deletes only the project and detaches its resources so they remain in the Checkly account as regular account-level resources
- Adds the flag to the options table, a `ResponseField` block under Command Options, and a clarifying note in the "What Gets Destroyed" section

## Test plan
- [ ] Preview the updated `cli/checkly-destroy.mdx` page in Mintlify and confirm the new flag renders in the options table, the `ResponseField`, and the "What Gets Destroyed" section
- [ ] Verify the described behavior matches the CLI implementation in `checkly-cli` (`packages/cli/src/commands/destroy.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)