### PR TITLE
feat(migration-image): add migration image documentation in the docs + update NET_RAW configuration guide - TREE-793

### DIFF
--- a/detect/uptime-monitoring/icmp-monitors/overview.mdx
+++ b/detect/uptime-monitoring/icmp-monitors/overview.mdx
@@ -83,8 +83,8 @@ Learn more in our documentation on [Results](/concepts/results).
 
 ## Troubleshooting Common Issues
 
-<Accordion title="Raw socket permission denied for ICMP, Traceroute, or Packet Capture on private locations">
-Container runtimes drop `NET_RAW` by default. ICMP monitors, Traceroute, and Packet Capture all need raw sockets, so the Checkly Agent needs this capability explicitly granted.
+<Accordion title="Raw socket permission denied for ICMP monitors on private locations">
+Container runtimes drop `NET_RAW` by default. ICMP monitors need raw sockets, so the Checkly Agent needs this capability explicitly granted.
 
 **How to fix**:
 

--- a/detect/uptime-monitoring/icmp-monitors/overview.mdx
+++ b/detect/uptime-monitoring/icmp-monitors/overview.mdx
@@ -105,6 +105,8 @@ In **Docker**:
 docker run --cap-add=NET_RAW ghcr.io/checkly/agent:latest
 ```
 
+Docker does not set `no_new_privs` by default, so `--cap-add` is sufficient. If you run with `--security-opt no-new-privileges`, file capabilities on binaries will be blocked — remove that flag to allow `NET_RAW`.
+
 `NET_RAW` only grants permission to create raw sockets. It does not escalate broader container privileges.
 </Accordion>
 

--- a/detect/uptime-monitoring/icmp-monitors/overview.mdx
+++ b/detect/uptime-monitoring/icmp-monitors/overview.mdx
@@ -83,7 +83,7 @@ Learn more in our documentation on [Results](/concepts/results).
 
 ## Troubleshooting Common Issues
 
-<Accordion title="NET_RAW capability error on private locations">
+<Accordion title="Raw socket permission denied for ICMP, Traceroute, or Packet Capture on private locations">
 Container runtimes drop `NET_RAW` by default. ICMP monitors, Traceroute, and Packet Capture all need raw sockets, so the Checkly Agent needs this capability explicitly granted.
 
 **How to fix**:

--- a/detect/uptime-monitoring/icmp-monitors/overview.mdx
+++ b/detect/uptime-monitoring/icmp-monitors/overview.mdx
@@ -84,14 +84,17 @@ Learn more in our documentation on [Results](/concepts/results).
 ## Troubleshooting Common Issues
 
 <Accordion title="NET_RAW capability error on private locations">
-Container runtimes drop the `NET_RAW` capability by default. ICMP requires raw sockets, so the Checkly Agent needs this capability explicitly granted.
+Container runtimes drop `NET_RAW` by default. ICMP monitors, Traceroute, and Packet Capture all need raw sockets, so the Checkly Agent needs this capability explicitly granted.
 
 **How to fix**:
 
 In **Kubernetes**, update your pod spec or Helm values:
+* `allowPrivilegeEscalation=true` — prevents Kubernetes from setting the `no_new_privs` bit on the container process, which would otherwise block file capabilities (like `cap_net_raw+ep` on the ping binary) from taking effect.
+* `capabilities.add=["NET_RAW"]` — adds `CAP_NET_RAW` to the container's bounding and permitted capability sets, allowing the kernel to open the raw sockets (`SOCK_RAW`).
 
 ```yaml
 securityContext:
+  allowPrivilegeEscalation: true
   capabilities:
     add: ["NET_RAW"]
 ```

--- a/platform/private-locations/agent-configuration.mdx
+++ b/platform/private-locations/agent-configuration.mdx
@@ -183,7 +183,7 @@ Each Checkly Agent only supports specific [runtimes](/platform/runtimes/overview
 
 | Agent version | Runtimes |
 |---------------|----------|
-| 7.0.0 | 2026.04, 2025.04 |
+| 7.0.0* | 2026.04, 2025.04 |
 | 6.0.0 | 2025.04, 2024.09 |
 | 5.0.0 | 2025.04 |
 | 4.0.0 | 2024.09 |
@@ -192,6 +192,10 @@ Each Checkly Agent only supports specific [runtimes](/platform/runtimes/overview
 | 3.2.0 | 2023.09 |
 | 2.0.0 | 2023.02 |
 | 1.3.9 | 2022.10 |
+
+<Tip>
+*If you're upgrading from runtime `2024.09` to `2026.04`, use the `7.0.2-migrate-202409-202604` migration image. It ships all three intermediate runtimes (`2024.09`, `2025.04`, `2026.04`) so you can migrate your checks incrementally.
+</Tip>
 
 As each agent version only supports specific runtimes, we recommend pinning agent versions used in production.
 

--- a/platform/private-locations/agent-configuration.mdx
+++ b/platform/private-locations/agent-configuration.mdx
@@ -201,8 +201,36 @@ As each agent version only supports specific runtimes, we recommend pinning agen
 
 ## Troubleshooting
 
+<Accordion title="Self-signed proxy certificate not trusted">
 If you're using a self-signed certificate for your proxy, the Agent's HTTP client will not trust it by default. There are two ways to fix this.
 
 1. Add your Certificate Authority's (CA) root certificate to the system's CA store. On Debian, and related Linux distributions, you can do this by copying your `*.crt` certificate to `/usr/local/share/ca-certificates/` and running `sudo update-ca-certificates`.
 2. Alternatively, you can tell the node process in the Agent's container to accept unauthorized certificates with the following environment variable, `NODE_TLS_REJECT_UNAUTHORIZED=0`. This can be appended to your `docker run ..` command with the `-e` flag.
+</Accordion>
 
+<Accordion title="Raw socket permission denied for Traceroute or Packet Capture on private locations">
+Container runtimes drop `NET_RAW` by default. Traceroute and Packet Capture need raw sockets, so the Checkly Agent needs this capability explicitly granted.
+
+**How to fix**:
+
+In **Kubernetes**, update your pod spec or Helm values:
+* `allowPrivilegeEscalation=true` — prevents Kubernetes from setting the `no_new_privs` bit on the container process, which would otherwise block file capabilities (like `cap_net_raw+ep`) from taking effect.
+* `capabilities.add=["NET_RAW"]` — adds `CAP_NET_RAW` to the container's bounding and permitted capability sets, allowing the kernel to open the raw sockets (`SOCK_RAW`).
+
+```yaml
+securityContext:
+  allowPrivilegeEscalation: true
+  capabilities:
+    add: ["NET_RAW"]
+```
+
+In **Docker**:
+
+```bash
+docker run --cap-add=NET_RAW ghcr.io/checkly/agent:latest
+```
+
+Docker does not set `no_new_privs` by default, so `--cap-add` is sufficient. If you run with `--security-opt no-new-privileges`, file capabilities on binaries will be blocked — remove that flag to allow `NET_RAW`.
+
+`NET_RAW` only grants permission to create raw sockets. It does not escalate broader container privileges.
+</Accordion>


### PR DESCRIPTION
## Affected Components

* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

## New Dependency Submission
* Documents the migration image and the usecase for it.
* Updates `NET_RAW` for PLs documentation to be aligned with the current working config.

## Screenshots

**Migration Image:**

<img width="1704" height="1049" alt="Screenshot 2026-04-21 at 16 39 02" src="https://github.com/user-attachments/assets/7828b2af-0452-4d79-b61e-2698356bb44c" />

**`NET_RAW` config for `ICMP` monitors:**

<img width="1698" height="1052" alt="Screenshot 2026-04-21 at 16 56 02" src="https://github.com/user-attachments/assets/f98e9d7e-e673-4ec1-80bd-7426aadb2e6c" />

**`NET_RAW` config for Traceroutes and PCAPs:**

<img width="1699" height="1048" alt="Screenshot 2026-04-21 at 16 55 27" src="https://github.com/user-attachments/assets/0d6b57e7-f7dd-4e42-b3d7-dc1bea87de9b" />

