### PR TITLE
skip incomplete API reference generations

### DIFF
--- a/.github/scripts/detect-new-endpoints.mjs
+++ b/.github/scripts/detect-new-endpoints.mjs
@@ -193,6 +193,29 @@ function getUniqueFilename(ep) {
   return `${baseFilename}-${Date.now()}`;
 }
 
+function getDocumentabilityIssues(ep, details) {
+  const issues = [];
+  const responseCodes = Object.keys(details.responses ?? {});
+  const nonDefaultResponses = responseCodes.filter(code => code !== 'default');
+
+  if (nonDefaultResponses.length === 0) {
+    issues.push('only has a default response');
+  }
+
+  const pathParams = [...ep.path.matchAll(/\{([^}]+)\}/g)].map(match => match[1]);
+  const documentedPathParams = new Set(
+    (details.parameters ?? [])
+      .filter(param => param?.in === 'path')
+      .map(param => param.name)
+  );
+  const missingPathParams = pathParams.filter(param => !documentedPathParams.has(param));
+  if (missingPathParams.length > 0) {
+    issues.push(`missing path parameter metadata: ${missingPathParams.join(', ')}`);
+  }
+
+  return issues;
+}
+
 function openPrExistsForBranchBase(branchBaseName) {
   try {
     const result = run(
@@ -382,6 +405,7 @@ async function main() {
 
   // 2. Find undocumented endpoints
   const undocumented = [];
+  const skippedPoorSpec = [];
   for (const [path, methods] of Object.entries(spec.paths)) {
     for (const [method, details] of Object.entries(methods)) {
       if (!['get', 'post', 'put', 'delete', 'patch'].includes(method)) continue;
@@ -398,8 +422,22 @@ async function main() {
       const { dir, group, subgroup } = resolveMapping(tag, summary);
 
       const ep = { key, method: method.toUpperCase(), path, tag, summary, dir, group, subgroup };
+      const documentabilityIssues = getDocumentabilityIssues(ep, details);
+      if (documentabilityIssues.length > 0) {
+        skippedPoorSpec.push({ ...ep, issues: documentabilityIssues });
+        continue;
+      }
+
       undocumented.push({ ...ep, filename: getUniqueFilename(ep) });
     }
+  }
+
+  if (skippedPoorSpec.length > 0) {
+    console.log(`\n⚠️  Skipping ${skippedPoorSpec.length} endpoint(s) with incomplete OpenAPI metadata:\n`);
+    for (const ep of skippedPoorSpec) {
+      console.log(`  ${ep.key} — ${ep.issues.join('; ')}`);
+    }
+    console.log('\n  Fix the upstream OpenAPI metadata before generating API reference pages for these endpoints.');
   }
 
   if (undocumented.length === 0) {


### PR DESCRIPTION
## Affected Components

* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

## Notes for the Reviewer

Adds a quality gate to the generated API endpoint PR workflow. The generator now skips undocumented operations when the OpenAPI metadata is too incomplete to render a useful Mintlify API Reference page.

For now it skips operations that:
- only expose a `default` response
- omit path parameter metadata for templated paths like `/v1/accounts/{accountId}/members`

This prevents creating technically valid MDX stubs that render as poor API docs because the upstream OpenAPI operation lacks response/status/schema/parameter detail.

Validation:
- `node --check .github/scripts/detect-new-endpoints.mjs`
- `DRY_RUN=1 node .github/scripts/detect-new-endpoints.mjs`

The dry run now skips the incomplete account members, cancel, and v2 check-session operations and only keeps endpoints with enough metadata to render useful reference pages.

## New Dependency Submission

None.

## Screenshots

No visual changes.
