### PR TITLE
docs: document account members CLI command

### DIFF
--- a/cli/checkly-account.mdx
+++ b/cli/checkly-account.mdx
@@ -1,12 +1,12 @@
 ---
 title: checkly account
-description: 'View your Checkly account plan, entitlements, and feature limits.'
+description: 'View your Checkly account plan, entitlements, feature limits, and members.'
 sidebarTitle: 'checkly account'
 ---
 
-<Note>Available since CLI v7.7.0.</Note>
+<Note>Available since CLI v7.7.0. The `members` subcommand is available since CLI v7.15.0.</Note>
 
-The `checkly account` command lets you view your account plan, entitlements, and feature limits directly from the terminal. Use it to check which features are available on your plan, inspect metered limits, and discover available check locations.
+The `checkly account` command lets you view account-level information directly from the terminal. Use it to check which features are available on your plan, inspect metered limits, discover available check locations, and list account members or pending invites.
 
 <Accordion title="Prerequisites">
 Before using `checkly account`, ensure you have:
@@ -27,7 +27,207 @@ npx checkly account <subcommand> [arguments] [options]
 
 | Subcommand | Description |
 |------------|-------------|
+| `members` | List account members and pending invites. |
 | `plan` | Show your account plan, entitlements, and feature limits. |
+
+## `checkly account members`
+
+List account members and pending invites for the currently selected account. Use filters to find users by email or name, inspect roles, or page through large member lists.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account members [options]
+```
+
+**Options:**
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--search, -s` | - | Search members and invites by name or email. |
+| `--type` | - | Filter by item type: `member` or `invite`. |
+| `--role` | - | Filter by member or invite role: `owner`, `admin`, `read_write`, `read_run`, or `read_only`. |
+| `--status` | - | Filter by member or invite status: `active`, `pending`, or `expired`. |
+| `--limit, -l` | - | Number of account members to return (1-100). Enables cursor pagination. |
+| `--next-id` | - | Cursor for the next page. Requires `--limit`. |
+| `--hide-id` | - | Hide member and invite IDs in formatted output. |
+| `--output, -o` | - | Output format: `table`, `json`, or `md`. Default: `table`. |
+
+### Members Options
+
+<ResponseField name="--search, -s" type="string">
+
+Search members and invites by name or email.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account members --search="alex"
+npx checkly account members -s "alex@example.com"
+```
+
+</ResponseField>
+
+<ResponseField name="--type" type="string">
+
+Filter the list by item type. Use `member` for active account members, or `invite` for pending and expired invites.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account members --type=member
+npx checkly account members --type=invite
+```
+
+</ResponseField>
+
+<ResponseField name="--role" type="string">
+
+Filter members and invites by role. Available values: `owner`, `admin`, `read_write`, `read_run`, `read_only`.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account members --role=admin
+npx checkly account members --role=read_only
+```
+
+</ResponseField>
+
+<ResponseField name="--status" type="string">
+
+Filter members and invites by status. Available values: `active`, `pending`, `expired`.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account members --status=active
+npx checkly account members --type=invite --status=pending
+```
+
+</ResponseField>
+
+<ResponseField name="--limit, -l" type="number">
+
+Set the number of account members to return, between 1 and 100. When you set `--limit`, the command prints pagination information and a next-page command when more results are available.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account members --limit=50
+npx checkly account members -l 10
+```
+
+</ResponseField>
+
+<ResponseField name="--next-id" type="string">
+
+Cursor for paginating through results. Use the `nextId` value from the JSON response, or the next-page command shown in table output. You must use `--limit` with `--next-id`.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account members --limit=10 --next-id=<nextId>
+```
+
+</ResponseField>
+
+<ResponseField name="--hide-id" type="boolean">
+
+Hide member and invite IDs in formatted output. JSON output always includes the response fields returned by the API.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account members --hide-id
+```
+
+</ResponseField>
+
+<ResponseField name="--output, -o" type="string" default="table">
+
+Set the output format. Use `json` for programmatic access or `md` for markdown.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account members --output=json
+npx checkly account members -o md
+```
+
+</ResponseField>
+
+### Members Examples
+
+```bash Terminal
+# List account members and pending invites
+npx checkly account members
+
+# Search by name or email
+npx checkly account members --search="alex"
+
+# Show only active members
+npx checkly account members --type=member --status=active
+
+# Show pending invites
+npx checkly account members --type=invite --status=pending
+
+# Find account admins
+npx checkly account members --role=admin
+
+# Get results as JSON
+npx checkly account members --output=json
+
+# Page through results
+npx checkly account members --limit=10 --next-id=<nextId>
+```
+
+### Members JSON Response
+
+The `--output=json` format returns a structured response with a `members` array and cursor pagination fields.
+
+```json
+{
+  "members": [
+    {
+      "type": "member",
+      "accountId": "123",
+      "userId": "usr_123",
+      "name": "Alex Doe",
+      "email": "alex@example.com",
+      "role": "ADMIN",
+      "status": "ACTIVE",
+      "createdAt": "2026-05-01T10:00:00.000Z",
+      "updatedAt": "2026-05-01T10:00:00.000Z",
+      "isSupportMembership": false,
+      "ssoEnabled": true,
+      "mfaEnabled": true
+    },
+    {
+      "type": "invite",
+      "id": "inv_123",
+      "accountId": "123",
+      "email": "new-user@example.com",
+      "role": "READ_ONLY",
+      "status": "PENDING",
+      "inviterEmail": "alex@example.com",
+      "createdAt": "2026-05-01T10:00:00.000Z",
+      "updatedAt": "2026-05-01T10:00:00.000Z",
+      "expiresAt": "2026-05-31T10:00:00.000Z"
+    }
+  ],
+  "length": 2,
+  "nextId": null
+}
+```
+
+Key fields:
+
+- **`members[].type`** — `member` for active account members or `invite` for account invites.
+- **`members[].role`** — account role, such as `OWNER`, `ADMIN`, `READ_WRITE`, `READ_RUN`, or `READ_ONLY`.
+- **`members[].status`** — `ACTIVE` for members, or `PENDING` / `EXPIRED` for invites.
+- **`length`** — number of items returned in the current response.
+- **`nextId`** — cursor for the next page. Use it with `--limit` and `--next-id`.
 
 ## `checkly account plan`
 


### PR DESCRIPTION
## Summary
- Document the new `checkly account members` subcommand on the existing account CLI reference page.
- Add the available flags, pagination behavior, examples, and JSON response shape based on `checkly@7.15.0`.
- Update the account command description and availability note to include the members subcommand.

## Validation
- `npx checkly@latest --version` -> `checkly/7.15.0`
- `npx checkly@latest account members --help`
- `python3 -m json.tool docs.json >/dev/null`
- `git diff --check`
- `npx mint broken-links` currently reports 125 existing broken links in unrelated files; none are from `cli/checkly-account.mdx`.

## Mintlify
- `Mintlify Deployment` reported `SKIPPED` with: `No eligible deployments found for changes` / `No changes to preview.`
