### PR TITLE
docs: add account members CLI version note

### DIFF
--- a/cli/checkly-account.mdx
+++ b/cli/checkly-account.mdx
@@ -4,7 +4,7 @@ description: 'View your Checkly account plan, entitlements, feature limits, and 
 sidebarTitle: 'checkly account'
 ---
 
-<Note>Available since CLI v7.7.0. The `members` subcommand is available since CLI v7.15.0.</Note>
+<Note>Available since CLI v7.7.0.</Note>
 
 The `checkly account` command lets you view account-level information directly from the terminal. Use it to check which features are available on your plan, inspect metered limits, discover available check locations, and list account members or pending invites.
 
@@ -31,6 +31,8 @@ npx checkly account <subcommand> [arguments] [options]
 | `plan` | Show your account plan, entitlements, and feature limits. |
 
 ## `checkly account members`
+
+<Note>The `checkly account members` command is only available since CLI v7.15.0.</Note>
 
 List account members and pending invites for the currently selected account. Use filters to find users by email or name, inspect roles, or page through large member lists.
 


### PR DESCRIPTION
## Summary
- Move the account members availability note into the `checkly account members` section.
- Clarify that `checkly account members` is only available since CLI v7.15.0.

## Validation
- `git diff --check`
- `python3 -m json.tool docs.json >/dev/null`