### PR TITLE
Deprecate legacy Swagger spec in API docs

### DIFF
--- a/api-reference/overview.mdx
+++ b/api-reference/overview.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Using the Checkly API'
 sidebarTitle: 'Overview'
+description: 'Use the Checkly Public API to manage monitoring resources, retrieve account information, and export analytics.'
 ---
 
 The Checkly API enables you to manage your monitoring infrastructure, retrieve account information, and export analytics using HTTP requests.
@@ -8,6 +9,14 @@ The Checkly API enables you to manage your monitoring infrastructure, retrieve a
 <Note>
   For creating and updating resources, we recommend using the [Checkly CLI](/cli/overview) or another [Monitoring as Code](/learn/monitoring/monitoring-as-code/) option. Managing resources using the Checkly API is possible, but Monitoring as Code generally provides a better experience for this.
 </Note>
+
+## API specification
+
+Use `https://api.checklyhq.com/openapi.json` for the current Checkly Public API specification.
+
+<Warning>
+  The legacy `https://api.checklyhq.com/swagger.json` specification is deprecated and no longer receives updates. If you generate API clients, validate requests, or inspect the latest API contract, update your tooling to use `openapi.json`.
+</Warning>
 
 ## Authentication
 


### PR DESCRIPTION
## What changed

- Adds an API specification section to the API Reference overview.
- Points users to `https://api.checklyhq.com/openapi.json` as the current Checkly Public API specification.
- Marks `https://api.checklyhq.com/swagger.json` as deprecated and no longer updated.
- Adds the required page `description` frontmatter while touching the page.

## Why

`openapi.json` is the up-to-date public API contract. The legacy Swagger 2.0 specification remains available for now, but should not be used for client generation or latest contract inspection going forward.

## Validation

- `git diff --check`
- `jq -e '.navigation.tabs[] | select(.tab == "API Reference")' docs.json`
- `npx mint broken-links` currently fails on existing repo-wide broken links unrelated to this one-file change; this PR does not add internal links.