### PR TITLE
docs: add v8 agent configuration to versions and runtimes

### DIFF
--- a/platform/private-locations/agent-configuration.mdx
+++ b/platform/private-locations/agent-configuration.mdx
@@ -183,6 +183,7 @@ Each Checkly Agent only supports specific [runtimes](/platform/runtimes/overview
 
 | Agent version | Runtimes |
 |---------------|----------|
+| 8.0.0 | 2026.04 |
 | 7.0.0* | 2026.04, 2025.04 |
 | 6.0.0 | 2025.04, 2024.09 |
 | 5.0.0 | 2025.04 |


### PR DESCRIPTION
## Affected Components

* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [X] Docs
* [ ] Learn
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Add v8 to the configuration overview.
