### PR TITLE
docs(alerts): document env vars + secrets support in alert-channel configs

### DIFF
--- a/communicate/alerts/channels.mdx
+++ b/communicate/alerts/channels.mdx
@@ -4,6 +4,8 @@ description: 'Configure notification channels to receive alerts when checks fail
 sidebarTitle: 'Channels'
 ---
 
+import AlertChannelSecrets from '/snippets/alert-channel-secrets-callout.mdx';
+
 Alert channels determine **how** alert notifications reach your team when checks fail, degrade, or recover. Checkly supports a wide range of notification methods to fit your team's communication preferences and operational workflows.
 
 ## Available Alert Channels
@@ -58,6 +60,12 @@ Verify the channel works correctly with test notifications
 </Step>
 </Steps>
 
+
+## Using variables and secrets in channel configs
+
+Any literal-secret field in an alert-channel configuration — webhook URL, API key, bearer token, PagerDuty service key, and so on — accepts a reference to an account [environment variable](/platform/variables) or [secret](/platform/secrets) using `{{NAME}}` syntax. The channel UI also lets you promote an inline value to a secret without leaving the page.
+
+<AlertChannelSecrets />
 
 <Tip>
 Use Checkly's alert notification log to track delivery success rates and identify any channels that frequently fail to deliver notifications.

--- a/integrations/alerts/webhooks.mdx
+++ b/integrations/alerts/webhooks.mdx
@@ -4,6 +4,8 @@ description: "Create custom webhook integrations to send Checkly alerts to any A
 sidebarTitle: "Webhooks"
 ---
 
+import AlertChannelSecrets from '/snippets/alert-channel-secrets-callout.mdx';
+
 <Tip>
   **Monitoring as Code**: Learn more about the [Webhook Alert Channel Construct](/constructs/webhook-alert-channel).
 </Tip>
@@ -20,7 +22,7 @@ Webhooks allow you to POST custom payloads to any endpoint in your own infrastru
 
 The example above shows a webhook configured to create a Jira ticket on each event. Notice the following:
 
-- We use the variable `JIRA_INSTANCE_URL` in the URL. We previously stored this variable in the [environment variables section](https://app.checklyhq.com/environment-variables). Alerting configurations only support the use of environment variables, secrets are not supported.
+- We use the variable `JIRA_INSTANCE_URL` in the URL. We previously stored this variable in the [environment variables section](https://app.checklyhq.com/environment-variables). Alert-channel configurations accept both [environment variables](/platform/variables) and [secrets](/platform/secrets) using the same `{{NAME}}` syntax.
 - We use the variable `CHECK_ID` in the payload. This is one of many event-based variables that will change with each call. See below for the complete list.
 
 In both cases we use the familiar Handlebars templating braces, i.e. `{{ }}` to insert the variable.
@@ -28,6 +30,8 @@ In both cases we use the familiar Handlebars templating braces, i.e. `{{ }}` to 
 <Note>
   To avoid encoding, you can access your environment variables with triple brackets, i.e. `{{{USER_API_KEY}}}`
 </Note>
+
+<AlertChannelSecrets />
 
 You can use the following event-related variables in both URL and payload.
 

--- a/integrations/incident-management/pagerduty.mdx
+++ b/integrations/incident-management/pagerduty.mdx
@@ -4,6 +4,14 @@ description: 'Learn how Checkly integrates seamlessly with PagerDuty, delivering
 sidebarTitle: 'PagerDuty'
 ---
 
+import AlertChannelSecrets from '/snippets/alert-channel-secrets-callout.mdx';
+
+<AlertChannelSecrets />
+
+<Note>
+The PagerDuty channel's `serviceKey` (integration key) accepts environment-variable references — e.g. `{{PAGERDUTY_SERVICE_KEY}}` — so you can store the integration key as an account secret instead of inline in the channel config.
+</Note>
+
 Checkly integrates with [Pagerduty](https://pagerduty.com) and can deliver all failure and recovery events
 to your Pagerduty account. After setting up the integration, Checkly will:
 

--- a/platform/secrets.mdx
+++ b/platform/secrets.mdx
@@ -140,6 +140,10 @@ process.env.CHECKLY_SECRET_TOKEN = await fetchFromAWS('auth-token')
 
 This is particularly useful for organizations that prefer not to store secrets in Checkly and want to maintain their existing secret management infrastructure. [Learn more about dynamic secret scrubbing](/platform/dynamic-secret-scrubbing).
 
+## Using secrets in alert channels
+
+Secrets also work in alert-channel configurations — webhook URLs, API keys, PagerDuty service keys, and any other literal-secret field accept the same `{{NAME}}` reference syntax. See [Alert channels](/communicate/alerts/channels) for details and the inline promote-to-secret affordance.
+
 ### Security and Usability Balance
 
 Use dedicated test users, test cards etc. These test users should have minimal privileges in your app. Do not use your admin or root user. Make sure you can easily disable or block these users without recourse.

--- a/snippets/alert-channel-secrets-callout.mdx
+++ b/snippets/alert-channel-secrets-callout.mdx
@@ -1,0 +1,7 @@
+<Note>
+**Using environment variables and secrets in this channel's config**
+
+Any literal-secret field in this alert channel — webhook URL, API key, bearer token, service key, etc. — accepts a [variable](/platform/variables) or [secret](/platform/secrets) reference using the familiar Handlebars syntax: `{{MY_VARIABLE}}`.
+
+You can also promote a value to a secret directly from the field: type the literal value, click the lock icon next to the input, and choose a name. The value is stored as an encrypted account secret and is never re-displayed in the UI.
+</Note>


### PR DESCRIPTION
Alert-channel configs now accept `{{NAME}}` refs to env vars and secrets, plus an inline promote-to-secret action. Shipped in monorepo #1810 (15 channels) and #1838 (PagerDuty `serviceKey`); flag removed, GA.

- Rewrites the false claim in `integrations/alerts/webhooks.mdx` ("secrets are not supported").
- Adds a canonical section to `communicate/alerts/channels.mdx` and a cross-link from `platform/secrets.mdx`.
- Calls out `serviceKey` in `integrations/incident-management/pagerduty.mdx` (last channel to gain support).
- One shared snippet (`snippets/alert-channel-secrets-callout.mdx`) referenced from those three pages.

Other channel pages intentionally untouched — the hub + secrets doc cover them.
