### PR TITLE
checks: centralize cross-cutting defaults on docsGroup

### DIFF
--- a/MONITORING_SETUP.md
+++ b/MONITORING_SETUP.md
@@ -19,14 +19,23 @@ docs/
 
 ## Checks
 
-| Check                       | Type    | Path                       | Frequency | Locations                          |
-| --------------------------- | ------- | -------------------------- | --------- | ---------------------------------- |
-| `docs-homepage-uptime`      | URL     | `/`                        | 5 min     | us-east-1, eu-west-1, ap-southeast-1 |
-| `docs-api-reference-uptime` | URL     | `/api-reference`           | 10 min    | us-east-1, eu-west-1               |
-| `docs-cli-uptime`           | URL     | `/cli`                     | 10 min    | us-east-1, eu-west-1               |
-| `docs-homepage-ux`          | Browser | `/`                        | 15 min    | us-east-1, eu-west-1               |
+All checks belong to the `docs-monitoring` group, which sets the shared defaults:
+
+- **Locations:** us-east-1, eu-west-1, ap-southeast-1 (parallel)
+- **Frequency:** 10 min default (overridable per check)
+- **Retry strategy:** fixed 30s backoff, 2 retries, same region
+- **Alert channel:** Slack `#ops`
+
+| Check                       | Type    | Path             | Frequency override |
+| --------------------------- | ------- | ---------------- | ------------------ |
+| `docs-homepage-uptime`      | URL     | `/`              | 5 min              |
+| `docs-api-reference-uptime` | URL     | `/api-reference` | —                  |
+| `docs-cli-uptime`           | URL     | `/cli`           | —                  |
+| `docs-homepage-ux`          | Browser | `/`              | 15 min             |
 
 Paths are appended to `DOCS_BASE_URL` (defaults to `https://www.checklyhq.com/docs`). URL monitors follow redirects and assert the final response is HTTP 200 within `degradedResponseTime` / `maxResponseTime` thresholds. The browser check verifies the page loads, the title matches `/Checkly/i`, and primary navigation is visible.
+
+Note: CheckGroupV2 makes `locations`, `runParallel`, and `retryStrategy` non-overridable from individual checks once set on the group. `frequency` and `tags` are inherited defaults that checks can override.
 
 The group is `muted: true` while the new monitoring is being shaken out — checks still run but no alerts fire. Unmute in `__checks__/group.ts` when ready.
 

--- a/MONITORING_SETUP.md
+++ b/MONITORING_SETUP.md
@@ -22,20 +22,19 @@ docs/
 All checks belong to the `docs-monitoring` group, which sets the shared defaults:
 
 - **Locations:** us-east-1, eu-west-1, ap-southeast-1 (parallel)
-- **Frequency:** 10 min default (overridable per check)
 - **Retry strategy:** fixed 30s backoff, 2 retries, same region
 - **Alert channel:** Slack `#ops`
 
-| Check                       | Type    | Path             | Frequency override |
-| --------------------------- | ------- | ---------------- | ------------------ |
-| `docs-homepage-uptime`      | URL     | `/`              | 5 min              |
-| `docs-api-reference-uptime` | URL     | `/api-reference` | —                  |
-| `docs-cli-uptime`           | URL     | `/cli`           | —                  |
-| `docs-homepage-ux`          | Browser | `/`              | 15 min             |
+| Check                       | Type    | Path             | Frequency |
+| --------------------------- | ------- | ---------------- | --------- |
+| `docs-homepage-uptime`      | URL     | `/`              | 5 min     |
+| `docs-api-reference-uptime` | URL     | `/api-reference` | 10 min    |
+| `docs-cli-uptime`           | URL     | `/cli`           | 10 min    |
+| `docs-homepage-ux`          | Browser | `/`              | 15 min    |
 
 Paths are appended to `DOCS_BASE_URL` (defaults to `https://www.checklyhq.com/docs`). URL monitors follow redirects and assert the final response is HTTP 200 within `degradedResponseTime` / `maxResponseTime` thresholds. The browser check verifies the page loads, the title matches `/Checkly/i`, and primary navigation is visible.
 
-Note: CheckGroupV2 makes `locations`, `runParallel`, and `retryStrategy` non-overridable from individual checks once set on the group. `frequency` and `tags` are inherited defaults that checks can override.
+Note: CheckGroupV2 makes `locations`, `runParallel`, and `retryStrategy` non-overridable from individual checks once set on the group.
 
 The group is `muted: true` while the new monitoring is being shaken out — checks still run but no alerts fire. Unmute in `__checks__/group.ts` when ready.
 

--- a/__checks__/group.ts
+++ b/__checks__/group.ts
@@ -1,4 +1,4 @@
-import { CheckGroupV2, Frequency, RetryStrategyBuilder } from 'checkly/constructs'
+import { CheckGroupV2, RetryStrategyBuilder } from 'checkly/constructs'
 import { slackChannelOps } from './alertChannels'
 
 export const docsGroup = new CheckGroupV2('docs-monitoring', {
@@ -8,7 +8,6 @@ export const docsGroup = new CheckGroupV2('docs-monitoring', {
   muted: true,
   locations: ['us-east-1', 'eu-west-1', 'ap-southeast-1'],
   runParallel: true,
-  frequency: Frequency.EVERY_10M,
   retryStrategy: RetryStrategyBuilder.fixedStrategy({
     baseBackoffSeconds: 30,
     maxRetries: 2,

--- a/__checks__/group.ts
+++ b/__checks__/group.ts
@@ -1,4 +1,4 @@
-import { CheckGroupV2 } from 'checkly/constructs'
+import { CheckGroupV2, Frequency, RetryStrategyBuilder } from 'checkly/constructs'
 import { slackChannelOps } from './alertChannels'
 
 export const docsGroup = new CheckGroupV2('docs-monitoring', {
@@ -6,4 +6,12 @@ export const docsGroup = new CheckGroupV2('docs-monitoring', {
   tags: ['docs'],
   alertChannels: [slackChannelOps],
   muted: true,
+  locations: ['us-east-1', 'eu-west-1', 'ap-southeast-1'],
+  runParallel: true,
+  frequency: Frequency.EVERY_10M,
+  retryStrategy: RetryStrategyBuilder.fixedStrategy({
+    baseBackoffSeconds: 30,
+    maxRetries: 2,
+    sameRegion: true,
+  }),
 })

--- a/__checks__/homepage-ux.check.ts
+++ b/__checks__/homepage-ux.check.ts
@@ -6,7 +6,6 @@ new BrowserCheck('docs-homepage-ux', {
   group: docsGroup,
   activated: true,
   frequency: Frequency.EVERY_15M,
-  locations: ['us-east-1', 'eu-west-1'],
   tags: ['docs'],
   code: {
     entrypoint: './homepage-ux.spec.ts',

--- a/__checks__/uptime.check.ts
+++ b/__checks__/uptime.check.ts
@@ -10,7 +10,6 @@ new UrlMonitor('docs-homepage-uptime', {
   group: docsGroup,
   activated: true,
   frequency: Frequency.EVERY_5M,
-  locations: ['us-east-1', 'eu-west-1', 'ap-southeast-1'],
   tags: ['docs'],
   degradedResponseTime: 3000,
   maxResponseTime: 10000,
@@ -26,8 +25,6 @@ new UrlMonitor('docs-api-reference-uptime', {
   name: 'Docs API reference uptime',
   group: docsGroup,
   activated: true,
-  frequency: Frequency.EVERY_10M,
-  locations: ['us-east-1', 'eu-west-1'],
   degradedResponseTime: 4000,
   maxResponseTime: 10000,
   request: {
@@ -42,8 +39,6 @@ new UrlMonitor('docs-cli-uptime', {
   name: 'Docs CLI uptime',
   group: docsGroup,
   activated: true,
-  frequency: Frequency.EVERY_10M,
-  locations: ['us-east-1', 'eu-west-1'],
   degradedResponseTime: 4000,
   maxResponseTime: 10000,
   request: {

--- a/__checks__/uptime.check.ts
+++ b/__checks__/uptime.check.ts
@@ -25,6 +25,7 @@ new UrlMonitor('docs-api-reference-uptime', {
   name: 'Docs API reference uptime',
   group: docsGroup,
   activated: true,
+  frequency: Frequency.EVERY_10M,
   degradedResponseTime: 4000,
   maxResponseTime: 10000,
   request: {
@@ -39,6 +40,7 @@ new UrlMonitor('docs-cli-uptime', {
   name: 'Docs CLI uptime',
   group: docsGroup,
   activated: true,
+  frequency: Frequency.EVERY_10M,
   degradedResponseTime: 4000,
   maxResponseTime: 10000,
   request: {

--- a/checkly.config.ts
+++ b/checkly.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig } from 'checkly'
-import { Frequency, RetryStrategyBuilder } from 'checkly/constructs'
 
 
 export default defineConfig({
@@ -8,16 +7,9 @@ export default defineConfig({
   repoUrl: 'https://github.com/checkly/docs',
   checks: {
     activated: true,
-    frequency: Frequency.EVERY_5M,
-    locations: ['us-east-1', 'eu-west-1', 'ap-southeast-1'],
     tags: ['docs'],
     checkMatch: '**/__checks__/**/*.check?(-group).{js,ts}',
     runtimeId: '2026.04',
-    retryStrategy: RetryStrategyBuilder.fixedStrategy({
-      baseBackoffSeconds: 30,
-      maxRetries: 2,
-      sameRegion: true,
-    }),
     playwrightConfig: {
       timeout: 120_000,
       expect: { timeout: 30_000 },


### PR DESCRIPTION
## Summary

Moves the cross-cutting settings shared by every docs monitor onto `docsGroup`, so individual check files only declare what's specific to them.

### Group-owned defaults (`__checks__/group.ts`)

- **Locations:** `us-east-1`, `eu-west-1`, `ap-southeast-1`
- **`runParallel: true`** — every check fans out across all three regions on each cycle
- **Retry strategy:** fixed 30s backoff, 2 retries, same region

`CheckGroupV2` makes these three non-overridable from member checks once set on the group, which is the desired behavior here — we want one location set and one retry policy across the docs monitoring.

### Stays per-check

- **`frequency`** — varies (5m / 10m / 15m); easier to read on each check than as "inherited from group"
- **`tags`** — `['docs']` on each check, also on the group
- Anything check-type-specific (Browser entrypoint, URL request settings, response-time thresholds, etc.)

### Project config (`checkly.config.ts`)

Trimmed: `locations`, `retryStrategy`, and the project-level `frequency` are removed — `checks:` defaults that the group already owns. Project keeps `activated`, `tags`, `checkMatch`, `runtimeId`, and `playwrightConfig`.

## Test plan

- [ ] `checkly deploy --preview` shows the three checks running from all three regions in parallel
- [ ] The two 10-min uptime checks (`docs-api-reference-uptime`, `docs-cli-uptime`) report `frequency: 10m`; the 5-min `docs-homepage-uptime` and 15-min `docs-homepage-ux` retain their cadences
- [ ] Group stays `muted: true` — no alerts fire from this PR