### PR TITLE
test: broken link in docs (do not merge)

### DIFF
--- a/what-is-checkly.mdx
+++ b/what-is-checkly.mdx
@@ -72,3 +72,5 @@ Detect both functional and performance errors in pre-production and production e
 **Full-Stack Engineering Teams** who want to shift monitoring left and treat monitoring as an integral part of their development process rather than an afterthought.
 
 **Engineering Teams Using Modern Web Technologies** who want monitoring that understands modern JavaScript frameworks, SPAs, and API-first architectures.
+
+See the [intentionally broken link](/this-page-does-not-exist-ci-test) — this PR is a CI test for the broken-links scan.


### PR DESCRIPTION
Smoke test that confirms the broken-links scan blocks the PR.

**Expected:**
- `static-docs-checks` → **fails** at the \`Broken-links scan\` step (the new link points to a non-existent page).
- `docs-gate` may also fail, since it waits on Mintlify's link-rot check which should catch the same link.
- `preview-checks` should pass — broken links are not a runtime failure for the preview-URL Checkly tests.

**Disposable** — close after observing.