### PR TITLE
test: openapi spec change (do not merge)

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1,4 +1,4 @@
-{"servers":[{"url":"https://api.checklyhq.com"}],"info":{"title":"Checkly Public API","version":"v1","description":"These are the docs for the newly released Checkly Public API.
+{"servers":[{"url":"https://api.checklyhq.com"}],"info":{"title":"Checkly Public API","version":"v1","description":"These are the docs for the Checkly Public API.
 If you have any questions, please do not hesitate to get in touch with us."},"security":[{"Bearer":[]}],"openapi":"3.0.0","components":{"securitySchemes":{"Bearer":{"type":"http","scheme":"bearer","bearerFormat":"Bearer","description":"The Checkly Public API uses API keys to authenticate requests. You can get the API Key [here](https://app.checklyhq.com/settings/user/api-keys).
 Your API key is like a password: 
 keep it secure!


### PR DESCRIPTION
Smoke test that confirms the openapi-check step fires when \`api-reference/openapi.json\` changes.

**Expected:**
- `static-docs-checks` runs both the \`Validate OpenAPI spec\` step (because openapi.json changed) **and** the broken-links scan (because the file is detected as a docs change). Should pass — locally verified the spec still validates.
- `docs-gate` waits for Mintlify checks and passes.
- `preview-checks` runs against the Mintlify preview. Should pass.

**Disposable** — close after observing.