### PR TITLE
ci: docs-CI cleanup — Mintlify skip handling, test session labels, non-docs PR optimization

### DIFF
--- a/.github/workflows/docs-gate.yml
+++ b/.github/workflows/docs-gate.yml
@@ -74,6 +74,22 @@ jobs:
           for attempt in $(seq 1 $MAX_ATTEMPTS); do
             CHECKS=$(gh api "repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs" --paginate)
 
+            # Short-circuit: if the Mintlify Deployment was skipped (e.g.
+            # Mintlify decided the change is a no-op), the dependent
+            # link-rot and vale-spellcheck checks never get posted. Exit
+            # successfully rather than time out waiting for them.
+            DEPLOY_CONCLUSION=$(echo "$CHECKS" | jq -r '
+              [.check_runs[] | select(.name == "Mintlify Deployment")]
+              | sort_by(.started_at) | reverse | .[0]
+              | if . == null or .status != "completed" then ""
+                else .conclusion // ""
+                end
+            ')
+            if [ "$DEPLOY_CONCLUSION" = "skipped" ]; then
+              echo "Mintlify Deployment was skipped — no preview to validate. Exiting successfully."
+              exit 0
+            fi
+
             ALL_DONE=true
             FAILED=""
 

--- a/.github/workflows/preview-checks.yml
+++ b/.github/workflows/preview-checks.yml
@@ -51,12 +51,28 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
           MAX_ATTEMPTS=40   # 40 * 30s = 20 min
           SLEEP=30
 
           for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            # Short-circuit: if Mintlify Deployment was skipped, no preview
+            # URL will ever appear. Skip the Checkly test run cleanly.
+            DEPLOY_CONCLUSION=$(gh api "repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs" --paginate --jq '
+              [.check_runs[] | select(.name == "Mintlify Deployment")]
+              | sort_by(.started_at) | reverse | .[0]
+              | if . == null or .status != "completed" then ""
+                else .conclusion // ""
+                end
+            ')
+            if [ "$DEPLOY_CONCLUSION" = "skipped" ]; then
+              echo "Mintlify Deployment was skipped — no preview to test."
+              echo "skipped=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
             COMMENT_BODY=$(gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
               --jq '[.[] | select(.user.login == "mintlify[bot]" and (.body | contains("mintlify-preview-comment")))] | last | .body // empty')
 
@@ -90,32 +106,32 @@ jobs:
           exit 1
 
       - name: Set up Node
-        if: steps.detect.outputs.docs_changed == 'true'
+        if: steps.detect.outputs.docs_changed == 'true' && steps.preview.outputs.skipped != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
-        if: steps.detect.outputs.docs_changed == 'true'
+        if: steps.detect.outputs.docs_changed == 'true' && steps.preview.outputs.skipped != 'true'
         run: npm ci
 
       - name: Run Checkly checks against preview
-        if: steps.detect.outputs.docs_changed == 'true'
+        if: steps.detect.outputs.docs_changed == 'true' && steps.preview.outputs.skipped != 'true'
         env:
           CHECKLY_API_KEY: ${{ secrets.CHECKLY_API_KEY }}
           CHECKLY_ACCOUNT_ID: ${{ secrets.CHECKLY_ACCOUNT_ID }}
           SLACK_OPS_WEBHOOK_URL: ${{ secrets.SLACK_OPS_WEBHOOK_URL }}
           DOCS_BASE_URL: ${{ steps.preview.outputs.url }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          CHECKLY_TEST_ENVIRONMENT: preview-pr-${{ github.event.pull_request.number }}
         run: |
           npx checkly test \
             --env "DOCS_BASE_URL=$DOCS_BASE_URL" \
             --record \
-            --test-session-name="Checkly Docs preview — PR #$PR_NUMBER" \
+            --test-session-name="Checkly docs" \
             --reporter=github \
             --timeout=1200
 
       - name: Publish Checkly report to step summary
-        if: always() && steps.detect.outputs.docs_changed == 'true'
+        if: always() && steps.detect.outputs.docs_changed == 'true' && steps.preview.outputs.skipped != 'true'
         run: cat checkly-github-report.md >> "$GITHUB_STEP_SUMMARY" || true

--- a/.github/workflows/preview-checks.yml
+++ b/.github/workflows/preview-checks.yml
@@ -3,11 +3,25 @@ name: Preview checks
 # Runs the Checkly synthetic checks against the Mintlify PR preview URL.
 # Skips silently when a PR touches no docs files. Fails when the Mintlify
 # preview itself failed (no URL to target).
+#
+# `paths-ignore` keeps the runner from spinning up at all on non-docs PRs.
+# The in-workflow detection below is the fine-grained backstop for the
+# rare case where a PR mixes docs and non-docs paths.
 
 on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - '.github/**'
+      - '**/*.sh'
+      - '*.md'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'node_modules/**'
+      - 'checkly.config.ts'
+      - 'block-headless.js'
+      - '__checks__/**'
 
 concurrency:
   group: preview-checks-${{ github.event.pull_request.number }}

--- a/.github/workflows/preview-checks.yml
+++ b/.github/workflows/preview-checks.yml
@@ -107,10 +107,12 @@ jobs:
           CHECKLY_ACCOUNT_ID: ${{ secrets.CHECKLY_ACCOUNT_ID }}
           SLACK_OPS_WEBHOOK_URL: ${{ secrets.SLACK_OPS_WEBHOOK_URL }}
           DOCS_BASE_URL: ${{ steps.preview.outputs.url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           npx checkly test \
             --env "DOCS_BASE_URL=$DOCS_BASE_URL" \
             --record \
+            --test-session-name="Checkly Docs preview — PR #$PR_NUMBER" \
             --reporter=github \
             --timeout=1200
 

--- a/.github/workflows/static-docs-checks.yml
+++ b/.github/workflows/static-docs-checks.yml
@@ -29,15 +29,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
       - name: Detect changed paths
         id: detect
         env:
@@ -61,6 +52,17 @@ jobs:
           else
             echo "docs_changed=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Set up Node
+        if: steps.detect.outputs.openapi_changed == 'true' || steps.detect.outputs.docs_changed == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        if: steps.detect.outputs.openapi_changed == 'true' || steps.detect.outputs.docs_changed == 'true'
+        run: npm ci
 
       - name: Validate OpenAPI spec
         if: steps.detect.outputs.openapi_changed == 'true'


### PR DESCRIPTION
## Summary

Three related fixes for the docs CI workflows.

### Short-circuit when Mintlify skips the preview deploy

When Mintlify returns `conclusion: skipped` on its Deployment check (e.g. on a trivial frontmatter-only change), the dependent `Mintlify Validation - link-rot` and `Mintlify Validation - vale-spellcheck` checks never get posted, and no preview URL appears in the PR comments. Today both `docs-gate` and `preview-checks` sit in their poll loops until the 30 / 20-minute timeout, then fail.

This change detects the skip via the Mintlify Deployment check-run and exits successfully:

- **`docs-gate`** — checks the latest `Mintlify Deployment` run at the top of each polling iteration. If it's `completed` with conclusion `skipped`, exit 0 immediately.
- **`preview-checks`** — same detection in the URL-wait step. Sets a `skipped=true` step output and gates the Node setup, install, test, and report-publish steps on it.

### Label Checkly test sessions by PR

In the same workflow file, the `checkly test` invocation now uses `--test-session-name="Checkly docs"` (plain) and exports `CHECKLY_TEST_ENVIRONMENT=preview-pr-<n>` so the PR number lands in the environment slot in Checkly's Test sessions list. Combined with the auto-detected branch / commit SHA, sessions are easy to map back to the originating PR.

### Skip runner spin-up on non-docs PRs

Two small wins on PRs that touch only the bits Mintlify doesn't render (workflow files, `__checks__/`, scripts, root-level `*.md`, etc.):

- **`preview-checks`** — adds `paths-ignore` at the workflow trigger so the runner doesn't start at all when every changed path matches the ignore list. The in-workflow detect step stays as a fine-grained backstop for mixed docs/non-docs PRs.
- **`static-docs-checks`** — reorders steps so detect runs first, then gates `Set up Node` and `npm ci` on `openapi_changed || docs_changed`. The workflow still always reports a status (it's a required check), but skips ~15–30s of install work when neither inner step will run.

Net effect: ~25–45s of runner time saved on every non-docs PR. No behavior change on docs PRs.

## Test plan

- [ ] On a docs PR where Mintlify deploys a preview, `preview-checks` runs normally and the resulting session shows up in Checkly as "Checkly docs" with environment `preview-pr-<n>`.
- [ ] On a docs PR where Mintlify skips deployment (e.g. trivial frontmatter change), both `docs-gate` and `preview-checks` exit successfully within a minute instead of timing out.
- [ ] On a non-docs PR (e.g. only `__checks__/` files), `preview-checks` doesn't start a runner at all and `static-docs-checks` skips both `Set up Node` and `npm ci`.