### PR TITLE
test: force preview-checks Checkly failure (do not merge)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://mintlify.com/docs.json",
   "theme": "aspen",
-  "name": "Checkly Docs",
+  "name": "Documentation Hub",
   "colors": {
     "primary": "#0075FF",
     "light": "#2B8AFF",

--- a/index.mdx
+++ b/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Checkly Documentation'
+title: 'Documentation Hub'
 description: 'The AI Native Application Reliability Platform built for modern engineering teams.'
 mode: "wide"
 


### PR DESCRIPTION
Smoke test that confirms the Checkly browser check actually fails when an assertion breaks.

The \`docs-homepage-ux\` browser check asserts \`expect(page).toHaveTitle(/Checkly/i)\`. This PR removes "Checkly" from both the homepage frontmatter title and \`docs.json\`'s site \`name\`, so the rendered \`<title>\` contains neither.

**Expected:**
- \`preview-checks\` should **fail** on the homepage-ux assertion.
- The URL monitors (homepage / api-reference / cli uptime) should still pass — they only check HTTP 200.
- \`static-docs-checks\` and \`docs-gate\` should pass — title isn't a link/spelling issue.
- Mintlify Deployment should pass — the page still renders, it just has a different title.

**Disposable** — close after observing.