### PR TITLE
docs: drop ts-node/typescript install step for CLI v8

### DIFF
--- a/cli/installation.mdx
+++ b/cli/installation.mdx
@@ -11,7 +11,7 @@ from scratch with the following steps.
 
 ## Prerequisites
 
-- Node.js `^20.19.0 || >=22.12.0`.
+- Node.js `20.19+` or `22.12+`.
 - A text editor like [Visual Studio Code](https://code.visualstudio.com/).
 
 ## Installation

--- a/cli/installation.mdx
+++ b/cli/installation.mdx
@@ -11,7 +11,7 @@ from scratch with the following steps.
 
 ## Prerequisites
 
-- Node.js `v16.x` or higher.
+- Node.js `^20.19.0 || >=22.12.0`.
 - A text editor like [Visual Studio Code](https://code.visualstudio.com/).
 
 ## Installation

--- a/cli/installation.mdx
+++ b/cli/installation.mdx
@@ -4,6 +4,8 @@ description: 'Creating a CLI project from scratch'
 sidebarTitle: 'Installation'
 ---
 
+import TsLoaderNote from '/snippets/ts-loader-note.mdx';
+
 To kickstart a new project with the CLI, we recommend running `npx checkly init`. But you can also add the CLI
 from scratch with the following steps.
 
@@ -20,11 +22,7 @@ First, install the CLI.
 npm i --save-dev checkly
 ```
 
-To use TypeScript, also install `ts-node` and `typescript`:
-
-```bash Terminal
-npm i --save-dev ts-node typescript
-```
+<TsLoaderNote />
 
 Create a minimal `checkly.config.ts` (or `checkly.config.js`) at the root of your project. We recommend using TypeScript.
 

--- a/detect/testing/creating-your-first-test.mdx
+++ b/detect/testing/creating-your-first-test.mdx
@@ -8,7 +8,7 @@ Checkly enables you to transform your existing Playwright tests into powerful sy
 
 <AccordionGroup>
 <Accordion title="Prerequisites">
-- Node.js `^20.19.0 || >=22.12.0` installed
+- Node.js `20.19+` or `22.12+` installed
 - A Checkly account (sign up at [checklyhq.com](https://www.checklyhq.com))
 - Basic familiarity with JavaScript/TypeScript
 </Accordion>

--- a/detect/testing/creating-your-first-test.mdx
+++ b/detect/testing/creating-your-first-test.mdx
@@ -8,7 +8,7 @@ Checkly enables you to transform your existing Playwright tests into powerful sy
 
 <AccordionGroup>
 <Accordion title="Prerequisites">
-- Node.js 18+ installed
+- Node.js `^20.19.0 || >=22.12.0` installed
 - A Checkly account (sign up at [checklyhq.com](https://www.checklyhq.com))
 - Basic familiarity with JavaScript/TypeScript
 </Accordion>

--- a/detect/uptime-monitoring/cli-configuration.mdx
+++ b/detect/uptime-monitoring/cli-configuration.mdx
@@ -477,7 +477,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies

--- a/guides/monitoring-ecommerce-apps-using-playwright.mdx
+++ b/guides/monitoring-ecommerce-apps-using-playwright.mdx
@@ -7,6 +7,7 @@ tags: Playwright
 
 import CliAuth from '/snippets/cli-auth.mdx';
 import CliProjectInit from '/snippets/cli-project-init.mdx';
+import TsLoaderNote from '/snippets/ts-loader-note.mdx';
 import { YoutubeEmbed } from "/snippets/youtube-embed.jsx"
 
 ## Inspired by Infrastructure-as-Code and E2E-Testing
@@ -187,11 +188,7 @@ First, install the CLI.
 npm install --save-dev checkly
 ```
 
-Since we are using TypeScript, also install ts-node and typescript:
-
-```bash install-typescript-dependencies
-npm install --save-dev ts-node typescript
-```
+<TsLoaderNote />
 
 Next up, we want to create our `checkly.config.ts` file and include the basic Checkly configuration as follows:
 

--- a/integrations/ci-cd/jenkins/overview.mdx
+++ b/integrations/ci-cd/jenkins/overview.mdx
@@ -63,7 +63,7 @@ should look as follows:
 pipeline {
     agent any
 
-    tools {nodejs "Node 18"}
+    tools {nodejs "Node 20"}
     environment {
         CHECKLY_API_KEY = credentials('checkly-api-key')
         CHECKLY_ACCOUNT_ID = credentials('checkly-account-id')

--- a/snippets/ts-loader-note.mdx
+++ b/snippets/ts-loader-note.mdx
@@ -1,0 +1,3 @@
+<Note>
+Built-in TypeScript support requires Checkly CLI `v8` or later. On earlier versions, also install a TypeScript loader with `npm install --save-dev ts-node typescript`.
+</Note>


### PR DESCRIPTION
## What

Checkly CLI [v8](https://github.com/checkly/checkly-cli/releases/tag/8.0.0) dropped `ts-node` as a TypeScript loader and raised its minimum Node.js version. This updates the docs to match.

## Changes

**TypeScript loader**
- Remove the `ts-node`/`typescript` install instructions from `cli/installation.mdx` and `guides/monitoring-ecommerce-apps-using-playwright.mdx` (v8 bundles `jiti` and supports TypeScript out of the box).
- Add a shared `snippets/ts-loader-note.mdx` callout, used on both pages, noting that built-in TypeScript support requires v8+ and that earlier versions still need the loader.

**Node.js version** (per [checkly-cli#1296](https://github.com/checkly/checkly-cli/pull/1296))
- Update the prerequisite in `cli/installation.mdx` (was `v16.x`) and `detect/testing/creating-your-first-test.mdx` (was `18+`) to `Node.js 20.19+ or 22.12+`.
- Phrased as the two LTS lines rather than a bare semver range, so readers don't assume Node 21 (excluded, EOL, no `require(ESM)` backport) works.

## Notes

Out of scope, left untouched: the ecommerce guide still imports from the old `@checkly/cli` package name (now `checkly`). Happy to fold that into a follow-up.