### PR TITLE
docs: drop jiti/TS-loader steps from getting-started guides

### DIFF
--- a/cli/checkly-init.mdx
+++ b/cli/checkly-init.mdx
@@ -49,7 +49,7 @@ npx checkly init -t cursor
 The `init` command detects your project context and adjusts its flow:
 
 - **No `package.json`** — prompts you to create one before continuing.
-- **No Checkly config** — creates a `checkly.config.ts` and installs `checkly` and `jiti` as dev dependencies.
+- **No Checkly config** — creates a `checkly.config.ts` and installs `checkly` as a dev dependency.
 - **Playwright detected** — provides context-aware setup that accounts for your existing test infrastructure.
 - **Existing Checkly project** — refreshes your agent skill to the latest version.
 

--- a/quickstarts/playwright-check.mdx
+++ b/quickstarts/playwright-check.mdx
@@ -4,9 +4,10 @@ description: 'Turn your Playwright tests into production monitors by creating a 
 sidebarTitle: 'Playwright Check Suite'
 ---
 
-import { YoutubeEmbed } from "/snippets/youtube-embed.jsx"
-import { CopyPromptButton } from "/snippets/copy-prompt-button.jsx"
-import SetupPrompt from "/snippets/playwright-check-suite-setup-prompt.mdx"
+import { CopyPromptButton } from "/snippets/copy-prompt-button.jsx";
+import SetupPrompt from "/snippets/playwright-check-suite-setup-prompt.mdx";
+import TsLoaderNote from '/snippets/ts-loader-note.mdx';
+import { YoutubeEmbed } from "/snippets/youtube-embed.jsx";
 
 Turn your Playwright tests into production monitors. Generate a working configuration with AI, or configure manually.
 
@@ -52,11 +53,7 @@ This prompt is also available in the Checkly UI when [creating a Playwright Chec
 npm install --save-dev checkly
 ```
 
-If you use TypeScript, also install `jiti` to bundle config and test files correctly:
-
-```bash terminal
-npm install --save-dev jiti
-```
+<TsLoaderNote />
 
 ## Step 2: Create Your checkly.config.ts
 

--- a/snippets/playwright-check-suite-setup-prompt.mdx
+++ b/snippets/playwright-check-suite-setup-prompt.mdx
@@ -45,7 +45,7 @@ Set up the smallest possible working Checkly Playwright Check Suite from this re
 * Use `pwProjects` and/or `pwTags` when that is the cleanest way to select tests.
 * Configure `frequency` and `locations` for the check suite based on my choices.
 * If needed, set `cli.runLocation` to one of the chosen locations for local validation.
-* If this repo uses TypeScript for config/tests, make sure `checkly` is installed and add `jiti` if needed.
+* If this repo uses TypeScript for config/tests, make sure `checkly` is installed.
 * Only customize `installCommand` or `testCommand` if the repo layout or package manager requires it.
 
 ### Alert Channel Setup

--- a/snippets/ts-loader-note.mdx
+++ b/snippets/ts-loader-note.mdx
@@ -1,3 +1,3 @@
 <Note>
-Built-in TypeScript support requires Checkly CLI `v8` or later. On earlier versions, also install a TypeScript loader with `npm install --save-dev ts-node typescript`.
+Built-in TypeScript support requires Checkly CLI `v8` or later. On earlier versions, also install a TypeScript loader with `npm install --save-dev jiti` (preferred) or `npm install --save-dev ts-node typescript`.
 </Note>


### PR DESCRIPTION
## What

Checkly CLI v8+ supports TypeScript out of the box, so a separate TypeScript loader install is no longer needed. This removes the `jiti` install steps from the getting-started/setup content and consolidates the pre-v8 guidance into the shared `ts-loader-note` snippet.

## Changes

- **`quickstarts/playwright-check.mdx`** — replace the hardcoded `jiti` install step with the shared `<TsLoaderNote />` snippet.
- **`cli/checkly-init.mdx`** — `checkly init` description no longer lists `jiti` as an installed dev dependency.
- **`snippets/playwright-check-suite-setup-prompt.mdx`** — AI setup prompt now only requires `checkly`, no `jiti`.
- **`snippets/ts-loader-note.mdx`** — pre-v8 note now lists `jiti` (preferred) or `ts-node typescript` as loader options.

## Why

v8 bundles TypeScript support, so the loader install is only relevant to users still on earlier CLI versions — and that single caveat now lives in one snippet instead of being duplicated (and inconsistently named) across pages.