### PR TITLE
docs: add checkly api command reference

### DIFF
--- a/cli/checkly-api.mdx
+++ b/cli/checkly-api.mdx
@@ -1,0 +1,149 @@
+---
+title: checkly api
+description: 'Make authenticated HTTP requests to the Checkly API from the command line.'
+sidebarTitle: 'checkly api'
+---
+
+The `checkly api` command makes authenticated HTTP requests to the Checkly API. It handles authentication automatically using your current login credentials, so you can query or update your account without manually managing API keys in request headers.
+
+<Accordion title="Prerequisites">
+Before using `checkly api`, ensure you have:
+
+- Checkly CLI installed
+- A valid Checkly account authentication (run `npx checkly login` if needed)
+
+See the [Authentication section](/cli/authentication) for other authentication options.
+</Accordion>
+
+## Usage
+
+```bash Terminal
+npx checkly api <endpoint> [options]
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `ENDPOINT` | API endpoint path, e.g. `/v1/checks`. |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `-X, --method` | HTTP method: `GET`, `POST`, `PUT`, `PATCH`, or `DELETE`. Defaults to `GET`. |
+| `-F, --field` | Add a request field as `key=value` (string) or `key:=value` (JSON-parsed). Can be used multiple times. |
+| `-H, --header` | Add a custom HTTP header as `"Key: Value"`. Can be used multiple times. |
+| `--input` | Read the request body from a file path, or `-` to read from stdin. |
+| `--jq` | Filter JSON output using a [jq](https://jqlang.org/) expression. Requires `jq` to be installed. |
+| `-i, --include` | Include HTTP status line and response headers in the output. |
+| `--verbose` | Print request and response headers to stderr. |
+
+## Examples
+
+### List all checks
+
+```bash Terminal
+npx checkly api /v1/checks
+```
+
+### Extract specific fields with jq
+
+```bash Terminal
+npx checkly api /v1/checks --jq '.[].name'
+```
+
+```
+"Heartbeat Check #1"
+"Product catalog"
+"Login flow"
+```
+
+### Paginate results
+
+Use `-F` to pass query parameters. The API returns 10 results per page by default.
+
+```bash Terminal
+# Get the first 5 checks
+npx checkly api /v1/checks -F limit=5
+
+# Get the second page
+npx checkly api /v1/checks -F limit=5 -F page=2
+```
+
+### Get a single resource
+
+```bash Terminal
+npx checkly api /v1/checks/<check-id>
+```
+
+### List alert channels
+
+```bash Terminal
+npx checkly api /v1/alert-channels --jq '[.[] | {id, type}]'
+```
+
+```json
+[
+  { "id": 263584, "type": "SMS" },
+  { "id": 263585, "type": "EMAIL" },
+  { "id": 263586, "type": "SLACK" }
+]
+```
+
+### Update a resource via stdin
+
+Pipe JSON directly into the command using `--input -`:
+
+```bash Terminal
+echo '{"activated": false}' | npx checkly api /v1/checks/<check-id> -X PUT --input -
+```
+
+Or read from a file:
+
+```bash Terminal
+npx checkly api /v1/checks/<check-id> -X PUT --input ./payload.json
+```
+
+### Inspect response headers
+
+Use `-i` to include the HTTP status and headers in the output:
+
+```bash Terminal
+npx checkly api /v1/checks -i
+```
+
+```
+HTTP/1.1 200 OK
+content-type: application/json; charset=utf-8
+content-range: 0-9/11
+...
+```
+
+The `content-range` header tells you the total number of results (`0-9/11` means page 1 of 11 items).
+
+### Debug a request
+
+Use `--verbose` to print request and response headers to stderr:
+
+```bash Terminal
+npx checkly api /v1/checks --verbose
+```
+
+```
+> GET /v1/checks
+
+< 200 OK
+< content-type: application/json; charset=utf-8
+< content-range: 0-9/11
+...
+```
+
+## Related Commands
+
+- [`checkly login`](/cli/checkly-login) - Sign in to your Checkly account
+- [`checkly whoami`](/cli/checkly-whoami) - Display current account and user information
+
+## API Reference
+
+For available endpoints, see the [Checkly API reference](/api-reference/overview).

--- a/cli/checkly-api.mdx
+++ b/cli/checkly-api.mdx
@@ -41,8 +41,8 @@ All flags are optional.
 
 | Option | Description |
 |--------|-------------|
-| `-X, --method` | HTTP method: `GET`, `POST`, `PUT`, `PATCH`, or `DELETE`. Defaults to `GET`. |
-| `-F, --field` | Add a request field as `key=value` (string) or `key:=value` (JSON-parsed). Can be used multiple times. |
+| `-X, --method` | HTTP method: `GET`, `POST`, `PUT`, `PATCH`, or `DELETE`. Defaults to `GET`, or `POST` when fields are present. |
+| `-F, --field` | Add a request body field as `key=value` (string) or `key:=value` (JSON-parsed). Can be used multiple times. |
 | `-H, --header` | Add a custom HTTP header as `"Key: Value"`. Can be used multiple times. |
 | `--input` | Read the request body from a file path, or `-` to read from stdin. |
 | `--jq` | Filter JSON output using a [jq](https://jqlang.org/) expression. Requires `jq` to be installed. |
@@ -77,14 +77,14 @@ npx checkly api /v1/checks --jq '.[].name'
 
 ### Paginate results
 
-Use `-F` to pass query parameters. The API returns 10 results per page by default.
+Use `-F` to pass query parameters. The API returns 10 results per page by default. Set `-X GET` explicitly, since the command otherwise switches to `POST` when fields are present.
 
 ```bash Terminal
 # Get the first 5 checks
-npx checkly api /v1/checks -F limit=5
+npx checkly api /v1/checks -X GET -F limit=5
 
 # Get the second page
-npx checkly api /v1/checks -F limit=5 -F page=2
+npx checkly api /v1/checks -X GET -F limit=5 -F page=2
 ```
 
 ### Get a single resource

--- a/cli/checkly-api.mdx
+++ b/cli/checkly-api.mdx
@@ -6,9 +6,9 @@ sidebarTitle: 'checkly api'
 
 <Note>Available since CLI v8.3.0.</Note>
 
-The `checkly api` command makes authenticated HTTP requests to the Checkly API. It handles authentication automatically using your current login credentials, so you can query or update your account without manually managing API keys in request headers. For available endpoints, refer to the [API reference](/api-reference/overview) or the [OpenAPI spec](https://api.checklyhq.com/openapi.json).
-
 <Tip>This command is primarily designed for agentic workflows — when you need to interact with the Checkly API but a dedicated CLI command doesn't exist yet for that operation. Make sure your [Checkly skills](/cli/checkly-skills) are up to date so your AI agent has the context it needs to use this command effectively.</Tip>
+
+The `checkly api` command makes authenticated HTTP requests to the Checkly API. It handles authentication automatically using your current login credentials, so you can query or update your account without manually managing API keys in request headers. For available endpoints, refer to the [API reference](/api-reference/overview) or the [OpenAPI spec](https://api.checklyhq.com/openapi.json).
 
 <Accordion title="Prerequisites">
 Before using `checkly api`, ensure you have:

--- a/cli/checkly-api.mdx
+++ b/cli/checkly-api.mdx
@@ -4,6 +4,8 @@ description: 'Make authenticated HTTP requests to the Checkly API from the comma
 sidebarTitle: 'checkly api'
 ---
 
+<Note>Available since CLI v8.3.0.</Note>
+
 The `checkly api` command makes authenticated HTTP requests to the Checkly API. It handles authentication automatically using your current login credentials, so you can query or update your account without manually managing API keys in request headers.
 
 <Accordion title="Prerequisites">

--- a/cli/checkly-api.mdx
+++ b/cli/checkly-api.mdx
@@ -8,7 +8,7 @@ sidebarTitle: 'checkly api'
 
 The `checkly api` command makes authenticated HTTP requests to the Checkly API. It handles authentication automatically using your current login credentials, so you can query or update your account without manually managing API keys in request headers.
 
-<Tip>This command is primarily designed for agentic workflows — when you need to interact with the Checkly API but a dedicated CLI command doesn't exist yet for that operation.</Tip>
+<Tip>This command is primarily designed for agentic workflows — when you need to interact with the Checkly API but a dedicated CLI command doesn't exist yet for that operation. Make sure your [Checkly skills](/cli/checkly-skills) are up to date so your AI agent has the context it needs to use this command effectively.</Tip>
 
 <Accordion title="Prerequisites">
 Before using `checkly api`, ensure you have:

--- a/cli/checkly-api.mdx
+++ b/cli/checkly-api.mdx
@@ -8,6 +8,8 @@ sidebarTitle: 'checkly api'
 
 The `checkly api` command makes authenticated HTTP requests to the Checkly API. It handles authentication automatically using your current login credentials, so you can query or update your account without manually managing API keys in request headers.
 
+<Tip>This command is primarily designed for agentic workflows — when you need to interact with the Checkly API but a dedicated CLI command doesn't exist yet for that operation.</Tip>
+
 <Accordion title="Prerequisites">
 Before using `checkly api`, ensure you have:
 

--- a/cli/checkly-api.mdx
+++ b/cli/checkly-api.mdx
@@ -14,7 +14,7 @@ The `checkly api` command makes authenticated HTTP requests to the Checkly API. 
 Before using `checkly api`, ensure you have:
 
 - Checkly CLI installed
-- A valid Checkly account authentication (run `npx checkly login` if needed)
+- Valid Checkly account authentication (run `npx checkly login` if needed)
 
 See the [Authentication section](/cli/authentication) for other authentication options.
 </Accordion>
@@ -42,7 +42,7 @@ All flags are optional.
 | Option | Description |
 |--------|-------------|
 | `-X, --method` | HTTP method: `GET`, `POST`, `PUT`, `PATCH`, or `DELETE`. Defaults to `GET`, or `POST` when fields are present. |
-| `-F, --field` | Add a request body field as `key=value` (string) or `key:=value` (JSON-parsed). Can be used multiple times. |
+| `-F, --field` | Add a field as `key=value` (string) or `key:=value` (JSON-parsed). Sent as a query parameter for `GET` requests and in the request body otherwise. Can be used multiple times. |
 | `-H, --header` | Add a custom HTTP header as `"Key: Value"`. Can be used multiple times. |
 | `--input` | Read the request body from a file path, or `-` to read from stdin. |
 | `--jq` | Filter JSON output using a [jq](https://jqlang.org/) expression. Requires `jq` to be installed. |
@@ -148,7 +148,7 @@ content-range: 0-9/11
 ...
 ```
 
-The `content-range` header tells you the total number of results (`0-9/11` means page 1 of 11 items).
+The `content-range` header tells you the total number of results (`0-9/11` means items 0–9 of 11 total).
 
 ### Debug a request
 

--- a/cli/checkly-api.mdx
+++ b/cli/checkly-api.mdx
@@ -6,7 +6,7 @@ sidebarTitle: 'checkly api'
 
 <Note>Available since CLI v8.3.0.</Note>
 
-The `checkly api` command makes authenticated HTTP requests to the Checkly API. It handles authentication automatically using your current login credentials, so you can query or update your account without manually managing API keys in request headers.
+The `checkly api` command makes authenticated HTTP requests to the Checkly API. It handles authentication automatically using your current login credentials, so you can query or update your account without manually managing API keys in request headers. For available endpoints, refer to the [API reference](/api-reference/overview) or the [OpenAPI spec](https://api.checklyhq.com/openapi.json).
 
 <Tip>This command is primarily designed for agentic workflows — when you need to interact with the Checkly API but a dedicated CLI command doesn't exist yet for that operation. Make sure your [Checkly skills](/cli/checkly-skills) are up to date so your AI agent has the context it needs to use this command effectively.</Tip>
 

--- a/cli/checkly-api.mdx
+++ b/cli/checkly-api.mdx
@@ -21,17 +21,23 @@ See the [Authentication section](/cli/authentication) for other authentication o
 
 ## Usage
 
+The basic command takes an API endpoint path and optional flags.
+
 ```bash Terminal
 npx checkly api <endpoint> [options]
 ```
 
 ## Arguments
 
+The command takes a single required argument.
+
 | Argument | Description |
 |----------|-------------|
 | `ENDPOINT` | API endpoint path, e.g. `/v1/checks`. |
 
 ## Options
+
+All flags are optional.
 
 | Option | Description |
 |--------|-------------|
@@ -45,13 +51,19 @@ npx checkly api <endpoint> [options]
 
 ## Examples
 
+The following examples cover common use cases for the `checkly api` command.
+
 ### List all checks
+
+Returns all checks in your account as JSON.
 
 ```bash Terminal
 npx checkly api /v1/checks
 ```
 
 ### Extract specific fields with jq
+
+Use `--jq` to filter or reshape the JSON response inline.
 
 <Note>`--jq` requires [jq](https://jqlang.org/) to be installed on your system.</Note>
 
@@ -79,11 +91,15 @@ npx checkly api /v1/checks -F limit=5 -F page=2
 
 ### Get a single resource
 
+Append the resource ID to the endpoint path to fetch a specific item.
+
 ```bash Terminal
 npx checkly api /v1/checks/<check-id>
 ```
 
 ### List alert channels
+
+Use `--jq` to extract only the fields you need from the response.
 
 ```bash Terminal
 npx checkly api /v1/alert-channels --jq '[.[] | {id, type}]'
@@ -146,6 +162,8 @@ npx checkly api /v1/checks --verbose
 ```
 
 ## Related Commands
+
+These commands are commonly used alongside `checkly api`.
 
 - [`checkly login`](/cli/checkly-login) - Sign in to your Checkly account
 - [`checkly whoami`](/cli/checkly-whoami) - Display current account and user information

--- a/cli/checkly-api.mdx
+++ b/cli/checkly-api.mdx
@@ -51,8 +51,6 @@ All flags are optional.
 
 ## Examples
 
-The following examples cover common use cases for the `checkly api` command.
-
 ### List all checks
 
 Returns all checks in your account as JSON.

--- a/cli/checkly-api.mdx
+++ b/cli/checkly-api.mdx
@@ -60,8 +60,8 @@ npx checkly api /v1/checks --jq '.[].name'
 ```
 
 ```
-"Heartbeat Check #1"
-"Product catalog"
+"My first check"
+"Homepage availability"
 "Login flow"
 ```
 

--- a/cli/checkly-api.mdx
+++ b/cli/checkly-api.mdx
@@ -53,6 +53,8 @@ npx checkly api /v1/checks
 
 ### Extract specific fields with jq
 
+<Note>`--jq` requires [jq](https://jqlang.org/) to be installed on your system.</Note>
+
 ```bash Terminal
 npx checkly api /v1/checks --jq '.[].name'
 ```

--- a/cli/checkly-api.mdx
+++ b/cli/checkly-api.mdx
@@ -127,6 +127,14 @@ Or read from a file:
 npx checkly api /v1/checks/<check-id> -X PUT --input ./payload.json
 ```
 
+### Add custom request headers
+
+Use `-H` to pass additional HTTP headers with the request. You can repeat the flag for multiple headers.
+
+```bash Terminal
+npx checkly api /v1/checks -H "Accept: application/json" -H "X-Custom-Header: value"
+```
+
 ### Inspect response headers
 
 Use `-i` to include the HTTP status and headers in the output:

--- a/docs.json
+++ b/docs.json
@@ -548,6 +548,7 @@
             "group": "CLI Commands",
             "pages": [
               "cli/checkly-account",
+              "cli/checkly-api",
               "cli/checkly-checks",
               "cli/checkly-deploy",
               "cli/checkly-destroy",


### PR DESCRIPTION
## Summary

- Adds `cli/checkly-api.mdx` documenting the `checkly api` pass-through command
- Registers it in `docs.json` navigation (alphabetically between `checkly-account` and `checkly-checks`)

## What's documented

- Usage, arguments, and all flags
- Verified working examples: GET, jq filtering, pagination, single-resource lookup, alert channels, PUT via stdin/file, custom request headers, header inspection (`-i`), and verbose debug mode (`--verbose`)
- Notes the `-F`/`-X` gotcha: `-F` adds request **body** fields and the command defaults to `POST` when fields are present, so query-param examples (pagination) pass `-X GET` explicitly

## Test plan

- [x] All code examples were tested against a real Checkly account before publishing
- [x] Navigation entry renders correctly in sidebar