### PR TITLE
docs(cli): document new commands from CLI v8.6–8.8

### DIFF
--- a/cli/checkly-account.mdx
+++ b/cli/checkly-account.mdx
@@ -28,6 +28,8 @@ npx checkly account <subcommand> [arguments] [options]
 | Subcommand | Description |
 |------------|-------------|
 | `members` | List account members and pending invites. |
+| `members update` | Update an account member role. |
+| `members delete` | Delete an account member. |
 | `plan` | Show your account plan, entitlements, and feature limits. |
 
 ## `checkly account members`
@@ -230,6 +232,219 @@ Key fields:
 - **`members[].status`** — `ACTIVE` for members, or `PENDING` / `EXPIRED` for invites.
 - **`length`** — number of items returned in the current response.
 - **`nextId`** — cursor for the next page. Use it with `--limit` and `--next-id`.
+
+## `checkly account members update`
+
+<Note>The `checkly account members update` command is only available since CLI v8.7.0.</Note>
+
+Update an account member's role. Identify the member by email or user ID. By default, the command shows the change and prompts for confirmation before proceeding.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account members update <member> --role=<role> [options]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `member` | The account member email or user ID. |
+
+**Options:**
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--role, -r` | Yes | New member role: `admin`, `read_write`, `read_run`, or `read_only`. |
+| `--email` | - | Treat the member argument as an email address. |
+| `--id` | - | Treat the member argument as a user ID. |
+| `--force, -f` | - | Skip the confirmation prompt. |
+| `--dry-run` | - | Preview what would happen without updating the member. |
+| `--output, -o` | - | Output format: `table`, `json`, or `md`. Default: `table`. |
+
+### Members Update Options
+
+<ResponseField name="--role, -r" type="string" required>
+
+The new role to assign. Available values: `admin`, `read_write`, `read_run`, `read_only`.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account members update alex@example.com --role=read_write
+npx checkly account members update alex@example.com -r admin
+```
+
+</ResponseField>
+
+<ResponseField name="--email" type="boolean" default="false">
+
+Treat the member argument as an email address. Use this to disambiguate when a value could be either an email or a user ID. Mutually exclusive with `--id`.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account members update alex@example.com --email --role=read_only
+```
+
+</ResponseField>
+
+<ResponseField name="--id" type="boolean" default="false">
+
+Treat the member argument as a user ID. Mutually exclusive with `--email`.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account members update usr_123 --id --role=read_only
+```
+
+</ResponseField>
+
+<ResponseField name="--force, -f" type="boolean" default="false">
+
+Skip the confirmation prompt and update the member immediately. Useful in scripts and CI.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account members update alex@example.com --role=admin --force
+```
+
+</ResponseField>
+
+<ResponseField name="--dry-run" type="boolean" default="false">
+
+Preview the role change without making any changes.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account members update alex@example.com --role=admin --dry-run
+```
+
+</ResponseField>
+
+<ResponseField name="--output, -o" type="string" default="table">
+
+Set the output format. Use `json` for programmatic access or `md` for markdown.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account members update alex@example.com --role=admin --output=json
+```
+
+</ResponseField>
+
+### Members Update Examples
+
+```bash Terminal
+# Update a member's role by email (with a confirmation prompt)
+npx checkly account members update alex@example.com --role=read_write
+
+# Update by user ID
+npx checkly account members update usr_123 --id --role=admin
+
+# Preview the change without applying it
+npx checkly account members update alex@example.com --role=admin --dry-run
+
+# Update without a confirmation prompt
+npx checkly account members update alex@example.com --role=admin --force
+```
+
+## `checkly account members delete`
+
+<Note>The `checkly account members delete` command is only available since CLI v8.7.0.</Note>
+
+Delete an account member. Identify the member by email or user ID. By default, the command shows the member to be removed and prompts for confirmation before proceeding.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account members delete <member> [options]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `member` | The account member email or user ID. |
+
+**Options:**
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--email` | - | Treat the member argument as an email address. |
+| `--id` | - | Treat the member argument as a user ID. |
+| `--force, -f` | - | Skip the confirmation prompt. |
+| `--dry-run` | - | Preview what would happen without deleting the member. |
+
+### Members Delete Options
+
+<ResponseField name="--email" type="boolean" default="false">
+
+Treat the member argument as an email address. Use this to disambiguate when a value could be either an email or a user ID. Mutually exclusive with `--id`.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account members delete alex@example.com --email
+```
+
+</ResponseField>
+
+<ResponseField name="--id" type="boolean" default="false">
+
+Treat the member argument as a user ID. Mutually exclusive with `--email`.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account members delete usr_123 --id
+```
+
+</ResponseField>
+
+<ResponseField name="--force, -f" type="boolean" default="false">
+
+Skip the confirmation prompt and delete the member immediately. Useful in scripts and CI.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account members delete alex@example.com --force
+```
+
+</ResponseField>
+
+<ResponseField name="--dry-run" type="boolean" default="false">
+
+Preview the deletion without making any changes.
+
+**Usage:**
+
+```bash Terminal
+npx checkly account members delete alex@example.com --dry-run
+```
+
+</ResponseField>
+
+### Members Delete Examples
+
+```bash Terminal
+# Delete a member by email (with a confirmation prompt)
+npx checkly account members delete alex@example.com
+
+# Delete by user ID
+npx checkly account members delete usr_123 --id
+
+# Preview the deletion without applying it
+npx checkly account members delete alex@example.com --dry-run
+
+# Delete without a confirmation prompt
+npx checkly account members delete alex@example.com --force
+```
 
 ## `checkly account plan`
 

--- a/cli/checkly-assets.mdx
+++ b/cli/checkly-assets.mdx
@@ -1,0 +1,334 @@
+---
+title: checkly assets
+description: 'List and download result assets such as logs, traces, videos, and screenshots.'
+sidebarTitle: 'checkly assets'
+---
+
+<Note>Available since CLI v8.8.0.</Note>
+
+The `checkly assets` command lets you list and download result assets from the terminal. Assets are the artifacts produced by a check run or [test session](/detect/testing/overview/) result, such as logs, Playwright traces, videos, screenshots, packet captures, and reports.
+
+Every asset belongs to a single result. Identify that result with `--result-id` together with either `--check-id` (for a scheduled check result) or `--test-session-id` (for a test-session result).
+
+<Accordion title="Prerequisites">
+Before using `checkly assets`, ensure you have:
+
+- Checkly CLI installed
+- Valid Checkly account authentication (run `npx checkly login` if needed)
+- A check result ID or test-session result ID, and its corresponding check ID or test session ID
+
+For additional setup information, see [CLI overview](/cli/overview).
+</Accordion>
+
+## Usage
+
+```bash Terminal
+npx checkly assets <subcommand> [options]
+```
+
+## Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `list` | List result assets. |
+| `download` | Download result assets. |
+
+## `checkly assets list`
+
+List the assets available for a check result or a test-session result. Use filters to narrow by asset type or name, then copy the exact `Asset` value to use with `checkly assets download`.
+
+**Usage:**
+
+```bash Terminal
+npx checkly assets list --result-id=<result-id> (--check-id=<check-id> | --test-session-id=<test-session-id>) [options]
+```
+
+**Options:**
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--result-id` | Yes | Check result ID or test-session result ID. |
+| `--check-id` | - | Check ID for a scheduled check result. Use one of `--check-id` or `--test-session-id`. |
+| `--test-session-id` | - | Test session ID for a test-session result. Use one of `--check-id` or `--test-session-id`. |
+| `--type` | - | Filter assets by type: `log`, `trace`, `video`, `screenshot`, `pcap`, `report`, `file`, or `all`. Default: `all`. |
+| `--asset` | - | Filter assets by exact `Asset`/`Name` value or glob. |
+| `--view` | - | Human output view: `table` or `tree`. Ignored with `--output json`. Default: `table`. |
+| `--output, -o` | - | Output format: `table`, `json`, or `md`. Default: `table`. |
+
+### List Options
+
+<ResponseField name="--result-id" type="string" required>
+
+The check result ID or test-session result ID to list assets for.
+
+**Usage:**
+
+```bash Terminal
+npx checkly assets list --result-id=<result-id> --check-id=<check-id>
+```
+
+</ResponseField>
+
+<ResponseField name="--check-id" type="string">
+
+The check ID for a scheduled check result. Use exactly one of `--check-id` or `--test-session-id`.
+
+**Usage:**
+
+```bash Terminal
+npx checkly assets list --result-id=<result-id> --check-id=<check-id>
+```
+
+</ResponseField>
+
+<ResponseField name="--test-session-id" type="string">
+
+The test session ID for a test-session result. Use exactly one of `--check-id` or `--test-session-id`.
+
+**Usage:**
+
+```bash Terminal
+npx checkly assets list --result-id=<result-id> --test-session-id=<test-session-id>
+```
+
+</ResponseField>
+
+<ResponseField name="--type" type="string" default="all">
+
+Filter assets by type. Available values: `log`, `trace`, `video`, `screenshot`, `pcap`, `report`, `file`, `all`.
+
+**Usage:**
+
+```bash Terminal
+npx checkly assets list --result-id=<result-id> --check-id=<check-id> --type=trace
+```
+
+</ResponseField>
+
+<ResponseField name="--asset" type="string">
+
+Filter assets by their exact `Asset`/`Name` value, or by a glob pattern.
+
+**Usage:**
+
+```bash Terminal
+npx checkly assets list --result-id=<result-id> --check-id=<check-id> --asset="trace.zip"
+npx checkly assets list --result-id=<result-id> --check-id=<check-id> --asset="*.png"
+```
+
+</ResponseField>
+
+<ResponseField name="--view" type="string" default="table">
+
+Choose the human-readable view. Use `table` to see exact `Asset` values for download, or `tree` for a hierarchical overview. This flag is ignored when `--output=json`.
+
+**Usage:**
+
+```bash Terminal
+npx checkly assets list --result-id=<result-id> --check-id=<check-id> --view=tree
+```
+
+</ResponseField>
+
+<ResponseField name="--output, -o" type="string" default="table">
+
+Set the output format. Use `json` for programmatic access or `md` for markdown.
+
+**Usage:**
+
+```bash Terminal
+npx checkly assets list --result-id=<result-id> --check-id=<check-id> --output=json
+npx checkly assets list --result-id=<result-id> --check-id=<check-id> -o md
+```
+
+</ResponseField>
+
+### List Examples
+
+```bash Terminal
+# List all assets for a check result
+npx checkly assets list --result-id=<result-id> --check-id=<check-id>
+
+# List all assets for a test-session result
+npx checkly assets list --result-id=<result-id> --test-session-id=<test-session-id>
+
+# Show only traces
+npx checkly assets list --result-id=<result-id> --check-id=<check-id> --type=trace
+
+# Filter assets by name with a glob
+npx checkly assets list --result-id=<result-id> --check-id=<check-id> --asset="*.png"
+
+# Show a hierarchical tree view
+npx checkly assets list --result-id=<result-id> --check-id=<check-id> --view=tree
+
+# Get the asset list as JSON
+npx checkly assets list --result-id=<result-id> --check-id=<check-id> --output=json
+```
+
+## `checkly assets download`
+
+Download assets for a check result or a test-session result. You must select assets with `--type` or `--asset` — use `--type all` to download everything. By default, files are written to `./checkly-assets/<source>-<result-id>`.
+
+**Usage:**
+
+```bash Terminal
+npx checkly assets download --result-id=<result-id> (--check-id=<check-id> | --test-session-id=<test-session-id>) (--type=<type> | --asset=<asset>) [options]
+```
+
+**Options:**
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--result-id` | Yes | Check result ID or test-session result ID. |
+| `--check-id` | - | Check ID for a scheduled check result. Use one of `--check-id` or `--test-session-id`. |
+| `--test-session-id` | - | Test session ID for a test-session result. Use one of `--check-id` or `--test-session-id`. |
+| `--type` | - | Select assets by type: `log`, `trace`, `video`, `screenshot`, `pcap`, `report`, `file`, or `all`. |
+| `--asset` | - | Select an asset by exact `Asset`/`Name` value or glob. |
+| `--dir` | - | Directory to write assets into. Default: `./checkly-assets/<source>-<result-id>`. |
+| `--force` | - | Overwrite existing files. Mutually exclusive with `--skip-existing`. |
+| `--skip-existing` | - | Skip files that already exist. Mutually exclusive with `--force`. |
+| `--output, -o` | - | Output format: `table` or `json`. Default: `table`. |
+
+<Note>Pass `--type` or `--asset` to select which assets to download. Use `--type all` to download all assets for the result.</Note>
+
+### Download Options
+
+<ResponseField name="--result-id" type="string" required>
+
+The check result ID or test-session result ID to download assets from.
+
+**Usage:**
+
+```bash Terminal
+npx checkly assets download --result-id=<result-id> --check-id=<check-id> --type=all
+```
+
+</ResponseField>
+
+<ResponseField name="--check-id" type="string">
+
+The check ID for a scheduled check result. Use exactly one of `--check-id` or `--test-session-id`.
+
+**Usage:**
+
+```bash Terminal
+npx checkly assets download --result-id=<result-id> --check-id=<check-id> --type=all
+```
+
+</ResponseField>
+
+<ResponseField name="--test-session-id" type="string">
+
+The test session ID for a test-session result. Use exactly one of `--check-id` or `--test-session-id`.
+
+**Usage:**
+
+```bash Terminal
+npx checkly assets download --result-id=<result-id> --test-session-id=<test-session-id> --type=all
+```
+
+</ResponseField>
+
+<ResponseField name="--type" type="string">
+
+Select assets by type. Available values: `log`, `trace`, `video`, `screenshot`, `pcap`, `report`, `file`, `all`. Use `--type all` to download every asset.
+
+**Usage:**
+
+```bash Terminal
+npx checkly assets download --result-id=<result-id> --check-id=<check-id> --type=video
+```
+
+</ResponseField>
+
+<ResponseField name="--asset" type="string">
+
+Select a single asset by its exact `Asset`/`Name` value, or by a glob pattern.
+
+**Usage:**
+
+```bash Terminal
+npx checkly assets download --result-id=<result-id> --check-id=<check-id> --asset="trace.zip"
+npx checkly assets download --result-id=<result-id> --check-id=<check-id> --asset="*.png"
+```
+
+</ResponseField>
+
+<ResponseField name="--dir" type="string">
+
+Directory to write the downloaded assets into. When omitted, assets are written to `./checkly-assets/<source>-<result-id>`.
+
+**Usage:**
+
+```bash Terminal
+npx checkly assets download --result-id=<result-id> --check-id=<check-id> --type=all --dir=./artifacts
+```
+
+</ResponseField>
+
+<ResponseField name="--force" type="boolean" default="false">
+
+Overwrite existing files in the target directory. Cannot be combined with `--skip-existing`.
+
+**Usage:**
+
+```bash Terminal
+npx checkly assets download --result-id=<result-id> --check-id=<check-id> --type=all --force
+```
+
+</ResponseField>
+
+<ResponseField name="--skip-existing" type="boolean" default="false">
+
+Skip files that already exist in the target directory. Cannot be combined with `--force`.
+
+**Usage:**
+
+```bash Terminal
+npx checkly assets download --result-id=<result-id> --check-id=<check-id> --type=all --skip-existing
+```
+
+</ResponseField>
+
+<ResponseField name="--output, -o" type="string" default="table">
+
+Set the output format. Use `json` for programmatic access, including the resolved directory and downloaded file paths.
+
+**Usage:**
+
+```bash Terminal
+npx checkly assets download --result-id=<result-id> --check-id=<check-id> --type=all --output=json
+```
+
+</ResponseField>
+
+### Download Examples
+
+```bash Terminal
+# Download all assets for a check result
+npx checkly assets download --result-id=<result-id> --check-id=<check-id> --type=all
+
+# Download all assets for a test-session result
+npx checkly assets download --result-id=<result-id> --test-session-id=<test-session-id> --type=all
+
+# Download only traces
+npx checkly assets download --result-id=<result-id> --check-id=<check-id> --type=trace
+
+# Download a single asset by name
+npx checkly assets download --result-id=<result-id> --check-id=<check-id> --asset="trace.zip"
+
+# Write assets to a custom directory
+npx checkly assets download --result-id=<result-id> --check-id=<check-id> --type=all --dir=./artifacts
+
+# Re-run without overwriting already-downloaded files
+npx checkly assets download --result-id=<result-id> --check-id=<check-id> --type=all --skip-existing
+
+# Get the download result as JSON
+npx checkly assets download --result-id=<result-id> --check-id=<check-id> --type=all --output=json
+```
+
+## Related Commands
+
+- [`checkly test-sessions`](/cli/checkly-test-sessions) - Inspect recorded test sessions and their results
+- [`checkly checks`](/cli/checkly-checks) - List, inspect, and analyze checks and their results
+- [`checkly rca`](/cli/checkly-rca) - Trigger root cause analysis for error groups

--- a/cli/checkly-checks.mdx
+++ b/cli/checkly-checks.mdx
@@ -30,6 +30,7 @@ npx checkly checks <subcommand> [arguments] [options]
 | `list` | List all checks in your account. |
 | `get` | Get details of a specific check, including recent results and analytics stats. |
 | `stats` | Show analytics stats for your checks. |
+| `delete` | Delete a check by ID. |
 
 ## `checkly checks list`
 
@@ -534,6 +535,75 @@ npx checkly checks stats --search="homepage" --output=json
 
 # Page through results
 npx checkly checks stats --limit=10 --page=2
+```
+
+## `checkly checks delete`
+
+<Note>The `checkly checks delete` command is only available since CLI v8.8.0.</Note>
+
+Delete a check by ID. By default, the command shows the check to be deleted and prompts for confirmation before proceeding.
+
+<Warning>
+Checks managed by a CLI project are recreated on the next `checkly deploy`. To permanently remove a project-managed check, delete it from your project code instead of using this command.
+</Warning>
+
+**Usage:**
+
+```bash Terminal
+npx checkly checks delete <id> [options]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `id` | The ID of the check to delete. |
+
+**Options:**
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--force, -f` | - | Skip the confirmation prompt. |
+| `--dry-run` | - | Preview what would happen without deleting the check. |
+
+### Delete Options
+
+<ResponseField name="--force, -f" type="boolean" default="false">
+
+Skip the confirmation prompt and delete the check immediately. Useful in scripts and CI.
+
+**Usage:**
+
+```bash Terminal
+npx checkly checks delete 12345 --force
+npx checkly checks delete 12345 -f
+```
+
+</ResponseField>
+
+<ResponseField name="--dry-run" type="boolean" default="false">
+
+Preview the deletion without making any changes. Shows the check that would be deleted.
+
+**Usage:**
+
+```bash Terminal
+npx checkly checks delete 12345 --dry-run
+```
+
+</ResponseField>
+
+### Delete Examples
+
+```bash Terminal
+# Delete a check with a confirmation prompt
+npx checkly checks delete 12345
+
+# Preview the deletion without making changes
+npx checkly checks delete 12345 --dry-run
+
+# Delete without a confirmation prompt
+npx checkly checks delete 12345 --force
 ```
 
 ## Related Commands

--- a/cli/checkly-test-sessions.mdx
+++ b/cli/checkly-test-sessions.mdx
@@ -6,7 +6,7 @@ sidebarTitle: 'checkly test-sessions'
 
 <Note>Available since CLI v8.4.0.</Note>
 
-The `checkly test-sessions` command lets you inspect recorded [test sessions](/detect/testing/overview/) from the terminal. Use it to review a session, wait for a running session to finish, or inspect a test session error group before starting root cause analysis.
+The `checkly test-sessions` command lets you inspect recorded [test sessions](/detect/testing/overview/) from the terminal. Use it to list recent sessions, review a session, wait for a running session to finish, or inspect a test session error group before starting root cause analysis.
 
 <Accordion title="Prerequisites">
 Before using `checkly test-sessions`, ensure you have:
@@ -28,7 +28,211 @@ npx checkly test-sessions <subcommand> [arguments] [options]
 
 | Subcommand | Description |
 |------------|-------------|
+| `list` | List recorded test sessions. |
 | `get` | Get details of a recorded test session. |
+
+## `checkly test-sessions list`
+
+<Note>The `checkly test-sessions list` command is only available since CLI v8.5.0.</Note>
+
+List recorded test sessions for the currently selected account. Use filters to narrow by status, branch, user, or provider, and cursor pagination to page through results.
+
+**Usage:**
+
+```bash Terminal
+npx checkly test-sessions list [options]
+```
+
+**Options:**
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--limit, -l` | - | Number of test sessions to return (1-100). Default: `20`. |
+| `--cursor` | - | Cursor for the next page (from previous output). |
+| `--from` | - | Only include test sessions created at or after this ISO date or Unix timestamp. |
+| `--to` | - | Only include test sessions created before this ISO date or Unix timestamp. |
+| `--status` | - | Filter by status: `running`, `failed`, `passed`, or `cancelled`. Can be specified multiple times. |
+| `--branch` | - | Filter by Git branch name. Can be specified multiple times. |
+| `--user` | - | Filter by commit owner or invoking user ID. Can be specified multiple times. |
+| `--no-users` | - | Include sessions with no commit owner and no invoking user. |
+| `--provider` | - | Filter by provider: `github`, `vercel`, `api`, `trigger`, or `pw_reporter`. Can be specified multiple times. |
+| `--search, -s` | - | Search test session text fields (3-200 characters). |
+| `--error-group` | - | Filter by test-session error group ID. |
+| `--output, -o` | - | Output format: `table`, `json`, or `md`. Default: `table`. |
+
+### List Options
+
+<ResponseField name="--limit, -l" type="number" default="20">
+
+Number of test sessions to return, between 1 and 100.
+
+**Usage:**
+
+```bash Terminal
+npx checkly test-sessions list --limit=50
+npx checkly test-sessions list -l 10
+```
+
+</ResponseField>
+
+<ResponseField name="--cursor" type="string">
+
+Cursor for paginating through results. Use the cursor value from the previous output, or the next-page command shown in table output.
+
+**Usage:**
+
+```bash Terminal
+npx checkly test-sessions list --limit=20 --cursor=<cursor>
+```
+
+</ResponseField>
+
+<ResponseField name="--from" type="string">
+
+Only include test sessions created at or after this point in time. Accepts an ISO date (such as `2026-06-01`) or a Unix timestamp in seconds.
+
+**Usage:**
+
+```bash Terminal
+npx checkly test-sessions list --from=2026-06-01
+```
+
+</ResponseField>
+
+<ResponseField name="--to" type="string">
+
+Only include test sessions created before this point in time. Accepts an ISO date or a Unix timestamp in seconds.
+
+**Usage:**
+
+```bash Terminal
+npx checkly test-sessions list --from=2026-06-01 --to=2026-06-15
+```
+
+</ResponseField>
+
+<ResponseField name="--status" type="string">
+
+Filter sessions by status. Available values: `running`, `failed`, `passed`, `cancelled`. Specify multiple times to match more than one status.
+
+**Usage:**
+
+```bash Terminal
+npx checkly test-sessions list --status=failed
+npx checkly test-sessions list --status=failed --status=running
+```
+
+</ResponseField>
+
+<ResponseField name="--branch" type="string">
+
+Filter sessions by Git branch name. Specify multiple times to match more than one branch.
+
+**Usage:**
+
+```bash Terminal
+npx checkly test-sessions list --branch=main
+npx checkly test-sessions list --branch=main --branch=staging
+```
+
+</ResponseField>
+
+<ResponseField name="--user" type="string">
+
+Filter sessions by commit owner or invoking user ID. Specify multiple times to match more than one user.
+
+**Usage:**
+
+```bash Terminal
+npx checkly test-sessions list --user=<user-id>
+```
+
+</ResponseField>
+
+<ResponseField name="--no-users" type="boolean">
+
+Include sessions that have no commit owner and no invoking user.
+
+**Usage:**
+
+```bash Terminal
+npx checkly test-sessions list --no-users
+```
+
+</ResponseField>
+
+<ResponseField name="--provider" type="string">
+
+Filter sessions by the provider that triggered them. Available values: `github`, `vercel`, `api`, `trigger`, `pw_reporter`. Specify multiple times to match more than one provider.
+
+**Usage:**
+
+```bash Terminal
+npx checkly test-sessions list --provider=github
+npx checkly test-sessions list --provider=trigger --provider=api
+```
+
+</ResponseField>
+
+<ResponseField name="--search, -s" type="string">
+
+Search test session text fields. The query must be between 3 and 200 characters.
+
+**Usage:**
+
+```bash Terminal
+npx checkly test-sessions list --search="checkout flow"
+npx checkly test-sessions list -s "homepage"
+```
+
+</ResponseField>
+
+<ResponseField name="--error-group" type="string">
+
+Filter sessions by a test-session error group ID.
+
+**Usage:**
+
+```bash Terminal
+npx checkly test-sessions list --error-group=<error-group-id>
+```
+
+</ResponseField>
+
+<ResponseField name="--output, -o" type="string" default="table">
+
+Set the output format. Use `json` for programmatic access or `md` for markdown.
+
+**Usage:**
+
+```bash Terminal
+npx checkly test-sessions list --output=json
+npx checkly test-sessions list -o md
+```
+
+</ResponseField>
+
+### List Examples
+
+```bash Terminal
+# List recent test sessions
+npx checkly test-sessions list
+
+# Show only failed sessions
+npx checkly test-sessions list --status=failed
+
+# Filter by branch and provider
+npx checkly test-sessions list --branch=main --provider=github
+
+# Filter by a time range
+npx checkly test-sessions list --from=2026-06-01 --to=2026-06-15
+
+# Get results as JSON
+npx checkly test-sessions list --output=json
+
+# Page through results
+npx checkly test-sessions list --limit=20 --cursor=<cursor>
+```
 
 ## `checkly test-sessions get`
 
@@ -50,6 +254,7 @@ npx checkly test-sessions get <id> [options]
 
 | Option | Required | Description |
 |--------|----------|-------------|
+| `--result, -r` | - | Show details for a specific test session result ID. |
 | `--error-group` | - | Show details for a test session error group ID from this session. |
 | `--error-groups-limit` | - | Number of error group IDs to show in the session summary. Default: `5`. |
 | `--full-error` | - | Print the complete raw error when showing a test session error group. |
@@ -57,6 +262,21 @@ npx checkly test-sessions get <id> [options]
 | `--output, -o` | - | Output format: `detail`, `json`, or `md`. Default: `detail`. |
 
 ### Get Options
+
+<ResponseField name="--result, -r" type="string">
+
+<Note>Available in CLI v8.7.0+.</Note>
+
+Drill into a specific test session result by its result ID. Shows detailed information for that result, including logs and timing data.
+
+**Usage:**
+
+```bash Terminal
+npx checkly test-sessions get <id> --result=<result-id>
+npx checkly test-sessions get <id> -r <result-id>
+```
+
+</ResponseField>
 
 <ResponseField name="--error-group" type="string">
 
@@ -131,6 +351,9 @@ npx checkly test-sessions get <id>
 # Wait for a running test session to complete
 npx checkly test-sessions get <id> --watch
 
+# Drill into a specific result
+npx checkly test-sessions get <id> --result=<result-id>
+
 # Inspect a test session error group
 npx checkly test-sessions get <id> --error-group=<error-group-id>
 
@@ -143,3 +366,4 @@ npx checkly test-sessions get <id> --output=json
 - [`checkly trigger`](/cli/checkly-trigger) - Trigger deployed checks as a test session
 - [`checkly test`](/cli/checkly-test) - Test local checks as a test session
 - [`checkly rca`](/cli/checkly-rca) - Trigger root cause analysis for error groups
+- [`checkly assets`](/cli/checkly-assets) - List and download result assets from a test session

--- a/docs.json
+++ b/docs.json
@@ -549,6 +549,7 @@
             "pages": [
               "cli/checkly-account",
               "cli/checkly-api",
+              "cli/checkly-assets",
               "cli/checkly-checks",
               "cli/checkly-deploy",
               "cli/checkly-destroy",


### PR DESCRIPTION
## Summary

Documents the CLI commands and flags added in recent releases (v8.6–v8.8, latest today) that were missing from the docs, so every CLI command is covered. Verified against the `checkly-cli` monorepo at the `8.8.0` tag.

### Changes

- **`checkly test-sessions`** (`cli/checkly-test-sessions.mdx`)
  - Add the `list` subcommand — *only available since CLI v8.5.0*
  - Add the `get --result, -r` flag — *available in CLI v8.7.0+*
- **`checkly assets`** (`cli/checkly-assets.mdx`, new page) — *available since CLI v8.8.0*
  - Document `list` and `download`, including source selection (`--result-id` with `--check-id`/`--test-session-id`), type/asset filters, and download options
  - Registered in `docs.json` navigation
- **`checkly checks`** (`cli/checkly-checks.mdx`)
  - Add the `delete` subcommand — *only available since CLI v8.8.0*
- **`checkly account`** (`cli/checkly-account.mdx`)
  - Add `members update` and `members delete` — *only available since CLI v8.7.0*

### Conventions

- Reuses the existing version-noting style: page-level `Available since CLI vX.Y.Z`, subcommand-level `The \`...\` command is only available since CLI vX.Y.Z`, and flag-level `Available in CLI vX.Y.Z+`.
- Matches the established page structure (Subcommands table → per-subcommand options table → `ResponseField` details → Examples).

### Verification

- `mint broken-links` passes (no broken links)
- `docs.json` validated as well-formed JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)