### PR TITLE
docs: prefer Slack App alert channels in agent guidance

### DIFF
--- a/guides/getting-started-with-monitoring-as-code.mdx
+++ b/guides/getting-started-with-monitoring-as-code.mdx
@@ -24,7 +24,7 @@ The [Checkly CLI](https://www.checklyhq.com/cli/overview) gives you a JavaScript
 
 Getting started is pretty easy. You can be up and running in no time to ensure your crucial web apps and sites are performing up to spec. The Checkly CLI provides two main workflows:
 
-- **Coding**: These encompass scripts (such as ApiCheck, BrowserCheck, or SlackAlertChannel) written in JavaScript/TypeScript. They are intended to be deployed and executed on the Checkly cloud backend.
+- **Coding**: These encompass scripts (such as ApiCheck, BrowserCheck, or SlackAppAlertChannel) written in JavaScript/TypeScript. They are intended to be deployed and executed on the Checkly cloud backend.
 - **Command**: These constitute the fundamental commands for executing your monitoring scripts. The `test` command is utilized for running monitoring checks locally or in continuous integration, while the `deploy` command is employed to push your monitoring scripts to the Checkly cloud backend.
 
 Let's jump into the step-by-step process.

--- a/guides/startup-guide-detect-communicate-resolve.mdx
+++ b/guides/startup-guide-detect-communicate-resolve.mdx
@@ -380,14 +380,13 @@ const smsChannel = new SmsAlertChannel('sms-channel-1', {
 })
 ```
 
-Here's another alert channel, this one for Slack.
+Here's another alert channel, this one for Slack using the Checkly Slack App.
 
-```ts {title="slack-alert-channel.ts"}
-import { SlackAlertChannel } from 'checkly/constructs'
+```ts {title="slack-app-alert-channel.ts"}
+import { SlackAppAlertChannel } from 'checkly/constructs'
 
-export const slackChannel = new SlackAlertChannel('slack-channel-1', {
-  url: new URL('https://hooks.slack.com/services/YOUR/SLACK/WEBHOOK'),
-  channel: '#alerts',
+export const slackChannel = new SlackAppAlertChannel('slack-channel-1', {
+  slackChannels: ['#alerts'],
   sendRecovery: true,
   sendFailure: true,
   sslExpiry: true,

--- a/snippets/playwright-check-suite-setup-prompt.mdx
+++ b/snippets/playwright-check-suite-setup-prompt.mdx
@@ -16,7 +16,7 @@ Set up the smallest possible working Checkly Playwright Check Suite from this re
 3. Select only a small subset of tests that are most suitable for synthetic monitoring. Do NOT try to cover the full codebase.
 4. Make sure the selected checks are fast, stable, and understandable.
 5. Let me choose the monitoring frequency and locations.
-6. Ask the user for their alert notification email and/or Slack webhook, then create at least one alert channel in code and assign it to all checks.
+6. Ask the user for their alert notification email and/or Slack App destination, then create at least one alert channel in code and assign it to all checks.
 7. Get me to a point where:
 
    * `npx checkly test --record` succeeds
@@ -55,11 +55,12 @@ Set up the smallest possible working Checkly Playwright Check Suite from this re
 **Before generating the config, you MUST ask the user for at least one of the following:**
 
 - **Email alerts:** Ask for their alert notification email address, then create an `EmailAlertChannel` with it.
-- **Slack alerts:** Ask for their Slack incoming webhook URL and channel name, then create a `SlackAlertChannel` with them.
+- **Slack App alerts:** Ask whether the Checkly Slack App is installed for their Slack workspace, then ask for the Slack `#channel` names or `@user` handles to notify and create a `SlackAppAlertChannel` with them.
+- **Legacy Slack webhook alerts:** Only ask for a Slack incoming webhook URL if the user explicitly needs to preserve or import an existing deprecated webhook-based Slack alert channel. Do not ask users to create a new Slack webhook for a new monitoring setup.
 
 The user can provide one or both. At minimum, one must be configured. **Do NOT use placeholder values like `alerts@example.com` or `<ALERT_EMAIL>` — always use the real values the user gives you.**
 
-If the user explicitly tells you they already have an alert channel configured in the Checkly UI and want to reuse it, use `EmailAlertChannel.fromId(<numeric_id>)` or `SlackAlertChannel.fromId(<numeric_id>)` instead. In that case, ask them for the numeric alert channel ID from the Checkly UI.
+If the user explicitly tells you they already have an alert channel configured in the Checkly UI and want to reuse it, use `EmailAlertChannel.fromId(<numeric_id>)` or `SlackAppAlertChannel.fromId(<numeric_id>)` instead. In that case, ask them for the numeric alert channel ID from the Checkly UI.
 
 ### checkly.config.ts — Exact Pattern
 
@@ -67,7 +68,7 @@ This is the ONLY file structure you should generate. All checks are defined inli
 
 ```typescript
 import { defineConfig } from 'checkly';
-import { EmailAlertChannel, SlackAlertChannel, Frequency } from 'checkly/constructs';
+import { EmailAlertChannel, SlackAppAlertChannel, Frequency } from 'checkly/constructs';
 
 // Email alert channel — remove this block if user does not provide an email
 const emailAlert = new EmailAlertChannel('default-email-alert', {
@@ -77,10 +78,9 @@ const emailAlert = new EmailAlertChannel('default-email-alert', {
   sendDegraded: false,
 });
 
-// Slack alert channel — remove this block if user does not provide a Slack webhook
-const slackAlert = new SlackAlertChannel('default-slack-alert', {
-  url: 'THE_ACTUAL_SLACK_WEBHOOK_URL_THE_USER_GAVE_YOU',
-  channel: 'THE_ACTUAL_SLACK_CHANNEL_THE_USER_GAVE_YOU',
+// Slack App alert channel — remove this block if user does not provide Slack App destinations
+const slackAlert = new SlackAppAlertChannel('default-slack-alert', {
+  slackChannels: ['THE_ACTUAL_SLACK_CHANNEL_OR_HANDLE_THE_USER_GAVE_YOU'],
   sendFailure: true,
   sendRecovery: true,
   sendDegraded: false,
@@ -117,7 +117,7 @@ export default defineConfig({
 **Import rules:**
 
 * `defineConfig` from `'checkly'`
-* `Frequency`, `EmailAlertChannel`, and `SlackAlertChannel` from `'checkly/constructs'` (NOT from `'checkly'`)
+* `Frequency`, `EmailAlertChannel`, and `SlackAppAlertChannel` from `'checkly/constructs'` (NOT from `'checkly'`)
 
 **Test selection — four strategies:**
 
@@ -306,7 +306,7 @@ use: {
 * frequency
 * locations
 * environment variables / secrets
-* alert notification email and/or Slack webhook
+* alert notification email and/or Slack App destination
 
 11. After implementation, provide a short final checklist confirming I should be able to run:
 
@@ -333,8 +333,8 @@ Use these defaults unless the repo makes them invalid. **For values marked "ASK 
 * Target environment/base URL: `https://staging.example.com`
 * Extra environment variables to wire in: `none`
 * Alert notification email: **ASK USER** — ask for their real email address
-* Slack webhook URL: **ASK USER** — ask for their Slack incoming webhook URL (optional if email is provided)
-* Slack channel: **ASK USER** — ask for their Slack channel name (optional if email is provided)
+* Slack App installed: **ASK USER** — ask whether the Checkly Slack App is installed for their Slack workspace (optional if email is provided)
+* Slack App destinations: **ASK USER** — ask for Slack `#channel` names or `@user` handles (optional if email is provided)
 
 ## Reference Documentation
 
@@ -346,7 +346,7 @@ Use these Checkly docs as the source of truth for the implementation:
 * [Environment Variables](https://www.checklyhq.com/docs/detect/synthetic-monitoring/playwright-checks/environment-variables/)
 * [Timeouts](https://www.checklyhq.com/docs/detect/synthetic-monitoring/playwright-checks/timeouts/)
 * [Email Alert Channel](https://www.checklyhq.com/docs/constructs/email-alert-channel/)
-* [Slack Alert Channel](https://www.checklyhq.com/docs/constructs/slack-alert-channel/)
+* [Slack App Alert Channel](https://www.checklyhq.com/docs/constructs/slack-app-alert-channel/)
 
 ---
 


### PR DESCRIPTION
## Summary

- Update the Playwright Check Suite setup prompt so agents ask for Slack App destinations instead of Slack incoming webhook URLs.
- Keep legacy webhook guidance only as an explicit preservation/import path for existing deprecated webhook channels.
- Refresh public guide examples to use `SlackAppAlertChannel`.

## Validation

- `git diff --check`

No docs build or lint script is available in this checkout beyond the Mint dev/test scripts.