### PR TITLE
docs: remove stray closing tags from interactions reference

### DIFF
--- a/skills/playwright-best-practices-for-agents/references/interactions.md
+++ b/skills/playwright-best-practices-for-agents/references/interactions.md
@@ -73,5 +73,3 @@ The agent CLI mirrors each — `press` for key presses, `hover` on a ref, and `d
 - [Playwright: Keyboard & mouse input](https://playwright.dev/docs/input)
 - [Playwright: Dialogs](https://playwright.dev/docs/dialogs)
 - [Clicking, typing, hovering](https://www.checklyhq.com/learn/playwright/clicking-typing-hovering/)
-</content>
-</invoke>


### PR DESCRIPTION
## What

Removes leftover `</content>` and `</invoke>` generation artifacts from the end of `skills/playwright-best-practices-for-agents/references/interactions.md`.

## Why

These stray XML-style closing tags were generation leftovers, not real content. A grep across `skills/` for `<content>`/`</content>`, `<invoke>`/`</invoke>`, and `antml` tags is now clean (the only other hit was in an untracked planning doc, `REVIEW-FINDINGS.md`, which is not part of the repo).