### PR TITLE
Add Devin CLI MCP setup docs

### DIFF
--- a/ai/mcp-server.mdx
+++ b/ai/mcp-server.mdx
@@ -13,7 +13,7 @@ https://api.checklyhq.com/mcp
 ```
 
 <Warning>
-The Checkly MCP Server only supports Checkly-approved clients that use OAuth Client ID Metadata Documents (CIMD). Clients that use Dynamic Client Registration (DCR) are rejected. See [setup requirements](/ai/mcp-server/setup) for supported clients and details.
+The Checkly MCP Server only supports Checkly-approved OAuth clients listed in setup. Clients that use Dynamic Client Registration (DCR) are rejected. See [setup requirements](/ai/mcp-server/setup) for supported clients and details.
 </Warning>
 
 Use it when your agent needs live Checkly account context, check status, check results, test sessions, root cause analyses, result assets, status pages, incidents, account environment variables, or when it needs to trigger existing checks.

--- a/ai/mcp-server/security-and-permissions.mdx
+++ b/ai/mcp-server/security-and-permissions.mdx
@@ -10,7 +10,7 @@ The Checkly MCP Server uses OAuth and Checkly account authorization together. OA
 
 The MCP Server accepts Auth0-issued bearer tokens for `https://api.checklyhq.com/mcp`. Your MCP client completes the OAuth flow and sends the token with requests to the MCP endpoint.
 
-The public MCP Server only supports OAuth clients that Checkly has approved in Auth0. Supported clients use [Client ID Metadata Documents (CIMD)](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/). Checkly rejects clients that attempt to use [Dynamic Client Registration (DCR)](https://datatracker.ietf.org/doc/html/rfc7591). See [known client limitations](/ai/mcp-server/setup#known-client-limitations) for unsupported clients.
+The public MCP Server only supports OAuth clients that Checkly has approved in Auth0. Checkly rejects clients that attempt to use [Dynamic Client Registration (DCR)](https://datatracker.ietf.org/doc/html/rfc7591). See [supported clients](/ai/mcp-server/setup#supported-clients) for setup details.
 
 Checkly maps the token subject to a Checkly user, then loads that user's account memberships and account context for tool calls.
 

--- a/ai/mcp-server/setup.mdx
+++ b/ai/mcp-server/setup.mdx
@@ -16,18 +16,21 @@ The Checkly MCP Server only supports the clients listed below. Clients that use 
 
 ## Supported clients
 
-The public Checkly MCP Server currently supports:
+The public Checkly MCP Server currently supports these clients:
 
-- ChatGPT
-- Claude Desktop
-- Claude Code
-- Antigravity
-- Cursor
-- VS Code
+| Client | Support status | Notes |
+| --- | --- | --- |
+| ChatGPT | Supported | Use the Checkly MCP endpoint from this page. |
+| Claude Desktop | Supported | Use the Checkly MCP endpoint as the remote MCP server URL. |
+| Claude Code | Supported | Add the server with the HTTP transport. |
+| Devin CLI | Supported | Requires Devin CLI and uses Checkly's static Devin MCP OAuth client. |
+| Antigravity | Supported | Use the Checkly MCP endpoint as the MCP server URL. |
+| Cursor | Supported | Uses Checkly's static Cursor MCP OAuth client. Configure `.cursor/mcp.json` or `~/.cursor/mcp.json`. |
+| VS Code | Supported | Configure `.vscode/mcp.json` or your VS Code user profile. |
 
-Each supported client uses [OAuth Client ID Metadata Documents (CIMD)](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/) and must be allowed by Checkly in Auth0 before it can connect. Clients that rely on DCR are not supported.
+Supported clients must use a Checkly-approved OAuth client in Auth0. Most supported clients use [OAuth Client ID Metadata Documents (CIMD)](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/). Cursor and Devin CLI use Checkly's static MCP OAuth clients. Clients that rely on DCR are not supported.
 
-If you want Checkly to support another CIMD-capable client, [share feedback or requests](https://feedback.checklyhq.com).
+If you want Checkly to support another compatible client, [share feedback or requests](https://feedback.checklyhq.com).
 
 ## ChatGPT
 
@@ -46,6 +49,28 @@ claude mcp add --transport http checkly https://api.checklyhq.com/mcp
 ```
 
 Start a Claude Code session and complete the OAuth flow when prompted.
+
+## Devin CLI
+
+Use this configuration:
+
+- MCP endpoint: `https://api.checklyhq.com/mcp`
+- OAuth client ID: `tpc_5apxvvouctRhwLo7ARsjYA`
+- Transport: `http`
+
+Add the server with the HTTP transport and Checkly's Devin OAuth client ID:
+
+```bash Terminal
+devin mcp add checkly https://api.checklyhq.com/mcp --transport http --oauth-client-id tpc_5apxvvouctRhwLo7ARsjYA
+```
+
+Then authenticate:
+
+```bash Terminal
+devin mcp login checkly --oauth-client-id tpc_5apxvvouctRhwLo7ARsjYA
+```
+
+Complete the OAuth flow when prompted.
 
 ## Antigravity
 
@@ -105,7 +130,7 @@ Restart VS Code after changing the configuration.
 
 ## Known client limitations
 
-Some MCP clients support remote MCP servers but do not work with the public Checkly MCP Server yet. If your preferred CIMD-capable client is missing, [share feedback or requests](https://feedback.checklyhq.com).
+Some MCP clients support remote MCP servers but do not work with the public Checkly MCP Server yet. If your preferred compatible client is missing, [share feedback or requests](https://feedback.checklyhq.com).
 
 ### Cline
 
@@ -114,10 +139,6 @@ Cline is not currently supported for Checkly MCP OAuth because of its current OA
 ### Windsurf / Devin Desktop
 
 Windsurf / Devin Desktop is not currently supported for Checkly MCP OAuth because of its current OAuth limitation. You can follow or upvote the [Checkly Devin support request](https://feedback.checklyhq.com/p/support-devin-devin-cli-for-checkly-mcp).
-
-### Devin CLI
-
-Devin CLI is not currently supported for Checkly MCP OAuth because of its current OAuth limitation. You can follow or upvote the [Checkly Devin support request](https://feedback.checklyhq.com/p/support-devin-devin-cli-for-checkly-mcp).
 
 ## Use a specific account
 

--- a/ai/mcp-server/troubleshooting.mdx
+++ b/ai/mcp-server/troubleshooting.mdx
@@ -29,7 +29,7 @@ If the browser login page shows an Auth0 "Something went wrong" error, contact [
 
 ## OAuth registration fails
 
-The Checkly MCP Server only supports clients that Checkly has approved in Auth0. Supported clients use OAuth Client ID Metadata Documents (CIMD). Checkly does not support Dynamic Client Registration (DCR).
+The Checkly MCP Server only supports clients that Checkly has approved in Auth0. Checkly does not support Dynamic Client Registration (DCR).
 
 If your client reports a dynamic registration error, a failed client registration, or never opens the expected OAuth flow, confirm that the client is in the [supported clients list](/ai/mcp-server/setup#supported-clients). Unsupported clients cannot connect to the public Checkly MCP Server, even if they support remote MCP servers.
 


### PR DESCRIPTION
## What changed

- Adds Devin CLI to the Checkly MCP supported-client table.
- Adds a Devin CLI setup section with the Checkly MCP endpoint, static OAuth client ID, HTTP transport, and setup/login commands.
- Removes Devin CLI from known unsupported client limitations.
- Updates adjacent OAuth compatibility wording so CIMD remains accurate while allowing Cursor and Devin CLI's static OAuth client paths.

## Why

Devin CLI is supported for Checkly MCP when configured with Checkly's static Devin MCP OAuth client.

## Validation

- Confirmed this patch matches `ee11f6bd95b5c2d34401454e06db6c22549d8dcb` by stable `git patch-id`.
- `npm exec --package=mint@4.2.259 -- mint broken-links`
- `git diff --cached --check`