### PR TITLE
Document Codex MCP limitation

### DIFF
--- a/ai/mcp-server/setup.mdx
+++ b/ai/mcp-server/setup.mdx
@@ -136,6 +136,10 @@ Some MCP clients support remote MCP servers but do not work with the public Chec
 
 Cline is not currently supported for Checkly MCP OAuth because of its current OAuth limitation. You can follow or upvote the [Checkly Cline support request](https://feedback.checklyhq.com/p/support-cline-as-mcp-client).
 
+### Codex
+
+Codex is not currently supported for Checkly MCP OAuth. Codex does not support CIMD for this flow, and Checkly cannot use a static OAuth client because Codex changes the callback port expected during OAuth. You can follow or upvote the [Checkly Codex support request](https://feedback.checklyhq.com/p/support-codex-for-checkly-mcp).
+
 ### Windsurf / Devin Desktop
 
 Windsurf / Devin Desktop is not currently supported for Checkly MCP OAuth because of its current OAuth limitation. You can follow or upvote the [Checkly Devin support request](https://feedback.checklyhq.com/p/support-devin-devin-cli-for-checkly-mcp).


### PR DESCRIPTION
## What changed

- Adds Codex to the known client limitations section for the Checkly MCP setup docs.
- Points users to the Codex support feature request so they can follow or upvote it.

## Why

Codex is not currently supported for Checkly MCP OAuth. Codex does not support CIMD for this flow, and Checkly cannot use a static OAuth client because Codex changes the callback port expected during OAuth.

## Validation

- `git diff --check`
- `npm exec --package=mint@4.2.259 -- mint broken-links`