### PR TITLE
Clarify private location unavailability timing

### DIFF
--- a/platform/private-locations/overview.mdx
+++ b/platform/private-locations/overview.mdx
@@ -84,7 +84,7 @@ new ApiCheck('hello-api-1', {
 
 ## Unavailable Private Locations
 
-If a private location has checks assigned but no Checkly agents connected for more than 20 minutes, it will be flagged as unavailable. Checkly will email account owners and admins when this happens.
+If a private location has checks assigned but no Checkly agents connected in the last 10 to 20 minutes, it will be flagged as unavailable. Checkly will email account owners and admins when this happens.
 
 While a location is unavailable, no checks will be scheduled to run on it. When a location becomes available, check scheduling and execution will resume automatically.
 


### PR DESCRIPTION
## Summary
- Update `platform/private-locations/overview.mdx` to clarify that a private location with no connected agents is flagged as unavailable after 10–20 minutes (rather than \"more than 20 minutes\").

## Test plan
- [ ] Verify wording renders correctly in the Mintlify preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)