### PR TITLE
Fix docs canonical domain (www) + probe trailing-slash override

### DIFF
--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -2,6 +2,7 @@
 title: Checkly CLI
 description: 'Code, test, and deploy synthetic monitoring at scale with the Checkly CLI.'
 sidebarTitle: 'Overview'
+canonical: 'https://www.checklyhq.com/docs/cli/overview/'
 ---
 
 import MainCicdCards from "/snippets/main-cicd-cards.mdx"

--- a/docs.json
+++ b/docs.json
@@ -9,7 +9,10 @@
   },
   "seo": {
     "title": "Getting started with Checkly - Checkly Docs",
-    "description": "The Application Reliability Platform built for modern engineering teams."
+    "description": "The Application Reliability Platform built for modern engineering teams.",
+    "metatags": {
+      "canonical": "https://www.checklyhq.com"
+    }
   },
   "favicon": "/racoon_favicon.png",
   "customCSS": "/style.css",


### PR DESCRIPTION
## What

Two SEO/canonical changes for the docs, following the P4 trailing-slash investigation.

### 1. Global canonical domain fix (`docs.json`) — the real change
Adds `seo.metatags.canonical: "https://www.checklyhq.com"`. Live docs pages currently emit `<link rel="canonical" href="https://checklyhq.com/docs/...">` — **bare domain**, which 301s to www, so the canonical is non-self-referential. This sets the canonical base to the www apex for **every page** in one line (Mintlify appends each page's path).

### 2. Trailing-slash probe (`cli/overview.mdx`) — temporary, review-only
Mintlify appends paths **without** a trailing slash, and has no global `trailingSlash` option, so the canonical will be `www` + no-slash (a single 308 to the served `.../overview/`). This commit adds a per-page `canonical:` frontmatter with an explicit trailing slash to **test whether Mintlify emits it verbatim or normalizes it away.**

## How to verify on the preview deploy

Once the Mintlify preview builds, check the rendered `<link rel="canonical">`:

1. **Any page** (e.g. `/docs/detect/overview/`) → should now be `https://www.checklyhq.com/...` (www, not bare). ✅ confirms the global fix.
2. **`/docs/cli/overview/`** → does the tag show a **trailing slash** (`.../cli/overview/`) or not?
   - **Slash preserved** → per-page override works; we can script it across all pages (deriving each canonical from its file path) if we decide the 1-hop is worth closing.
   - **Slash stripped** → Mintlify normalizes it; drop commit 2 and accept `www` + no-slash (Google already indexes the slash form regardless).

## Merge guidance
- Commit 1 (`docs.json`) is safe to keep regardless.
- Commit 2 (`cli/overview.mdx`) is a **probe** — keep only if the slash survives *and* we choose to pursue per-page canonicals; otherwise drop it before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
