### PR TITLE
Fix canonical base to include /docs mount path

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -11,7 +11,7 @@
     "title": "Getting started with Checkly - Checkly Docs",
     "description": "The Application Reliability Platform built for modern engineering teams.",
     "metatags": {
-      "canonical": "https://www.checklyhq.com"
+      "canonical": "https://www.checklyhq.com/docs"
     }
   },
   "favicon": "/racoon_favicon.png",


### PR DESCRIPTION
Hotfix for #420. The global `seo.metatags.canonical` was set to the bare origin `https://www.checklyhq.com`, so Mintlify emitted canonicals **without the `/docs` mount** (e.g. `https://www.checklyhq.com/detect/overview` instead of `.../docs/detect/overview`) — non-self-referential on every non-overridden page.

This sets the base to `https://www.checklyhq.com/docs` so canonicals resolve to the real served path.

**Verified on prod after #420:**
- ✅ Per-page `canonical:` overrides emit verbatim — `/docs/cli/overview/` → `https://www.checklyhq.com/docs/cli/overview/` (www + /docs + trailing slash).
- ❌ Global base without /docs dropped the mount — fixed here.

After deploy, non-overridden pages should read `https://www.checklyhq.com/docs/<path>` (www + /docs, no trailing slash — a single 308 to the served slash URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)