### PR TITLE
Experiment: trailing-slash canonical on 20 top docs pages (+ canonical base fix)

### DIFF
--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -2,7 +2,6 @@
 title: Checkly CLI
 description: 'Code, test, and deploy synthetic monitoring at scale with the Checkly CLI.'
 sidebarTitle: 'Overview'
-canonical: 'https://www.checklyhq.com/docs/cli/overview/'
 ---
 
 import MainCicdCards from "/snippets/main-cicd-cards.mdx"

--- a/comparisons/frameworks/playwright-vs-cypress.mdx
+++ b/comparisons/frameworks/playwright-vs-cypress.mdx
@@ -12,6 +12,7 @@ displayTitle: Playwright vs Cypress
 sidebarTitle: Playwright vs Cypress
 learn_playwright:
   parent: "Getting started"
+canonical: 'https://www.checklyhq.com/docs/comparisons/frameworks/playwright-vs-cypress/'
 ---
 Playwright and Cypress are two frameworks both closely associated with end-to-end testing of production websites. Both frameworks can do quite a bit more than 'making sure nothing on your site is broken' and their design philosophies, architectures, and use cases are different.
 

--- a/detect/synthetic-monitoring/api-checks/overview.mdx
+++ b/detect/synthetic-monitoring/api-checks/overview.mdx
@@ -2,6 +2,7 @@
 title: 'API Checks Overview'
 description: 'Monitor API endpoints with comprehensive HTTP request validation, performance testing, and detailed response analysis.'
 sidebarTitle: 'Overview'
+canonical: 'https://www.checklyhq.com/docs/detect/synthetic-monitoring/api-checks/overview/'
 ---
 <Tip>
 **Monitoring as Code**: Learn more about the [API Check Construct](/constructs/api-check).

--- a/detect/uptime-monitoring/tcp-monitors/overview.mdx
+++ b/detect/uptime-monitoring/tcp-monitors/overview.mdx
@@ -2,6 +2,7 @@
 title: 'TCP Monitors Overview'
 description: 'Monitor the availability and performance of your TCP services.'
 sidebarTitle: Overview
+canonical: 'https://www.checklyhq.com/docs/detect/uptime-monitoring/tcp-monitors/overview/'
 ---
 
 <Tip>

--- a/docs.json
+++ b/docs.json
@@ -11,7 +11,7 @@
     "title": "Getting started with Checkly - Checkly Docs",
     "description": "The Application Reliability Platform built for modern engineering teams.",
     "metatags": {
-      "canonical": "https://www.checklyhq.com"
+      "canonical": "https://www.checklyhq.com/docs"
     }
   },
   "favicon": "/racoon_favicon.png",

--- a/guides/auto-waiting-methods.mdx
+++ b/guides/auto-waiting-methods.mdx
@@ -5,6 +5,7 @@ description: >-
   Playwright's auto-waiting is a great feature to avoid test flakiness, but in some situations it doesn't work as expected, what are the alternatives?
 tags:
   - FAQ
+canonical: 'https://www.checklyhq.com/docs/guides/auto-waiting-methods/'
 ---
 
 import PlaywrightCheckSuiteTryOut from "/snippets/playwright-check-suite-tryout.mdx"

--- a/guides/end-to-end-monitoring.mdx
+++ b/guides/end-to-end-monitoring.mdx
@@ -3,6 +3,7 @@ title: What is End to End Monitoring? An Overview with Examples
 description: Learn end-to-end monitoring with playwright to test key website flows. Follow our guide that gets you up and running in 10 minutes.
 tags: Playwright
 sidebarTitle: What is End-to-End Monitoring?
+canonical: 'https://www.checklyhq.com/docs/guides/end-to-end-monitoring/'
 ---
 ## An overview of end-to-end monitoring
 

--- a/integrations/alerts/telegram.mdx
+++ b/integrations/alerts/telegram.mdx
@@ -2,6 +2,7 @@
 title: 'Send Alerts via Telegram'
 description: 'Find out how Checkly integrates with Telegram to send failure, degradation, and recovery messages to any chat'
 sidebarTitle: 'Telegram'
+canonical: 'https://www.checklyhq.com/docs/integrations/alerts/telegram/'
 ---
 
 Checkly integrates with [Telegram](https://telegram.org/) and can 

--- a/learn/incidents/slo-sla-sli.mdx
+++ b/learn/incidents/slo-sla-sli.mdx
@@ -10,6 +10,7 @@ displayDescription:
 weight: 121
 learn_incidents:
   parent: Detection
+canonical: 'https://www.checklyhq.com/docs/learn/incidents/slo-sla-sli/'
 ---
 
 When we talk about keeping services running smoothly, we often hear about SLAs, SLOs, and SLIs. But what do these terms mean, and how are they different? SLAs, or Service Level Agreements, are like promises between a service provider and a customer. They outline what the customer can expect in terms of service quality.

--- a/learn/kubernetes/monitoring-challenges.mdx
+++ b/learn/kubernetes/monitoring-challenges.mdx
@@ -9,6 +9,7 @@ githubUser: serverless-mom
 displayDescription: 
   We explore the unique challenges of monitoring Kubernetes environments and the open-source tools that can improve visibility and control.
 weight: 1
+canonical: 'https://www.checklyhq.com/docs/learn/kubernetes/monitoring-challenges/'
 ---
 Managing Kubernetes in production is no small feat, especially when it comes to monitoring and observability. As modern applications grow in complexity, traditional methods of monitoring, limited to CPU and memory usage, often fall short. In this article, we explore the unique challenges of monitoring Kubernetes environments and the open-source tools that can improve visibility and control.
 

--- a/learn/kubernetes/structured-logging.mdx
+++ b/learn/kubernetes/structured-logging.mdx
@@ -10,6 +10,7 @@ displayDescription:
   Best practices for structured logging.
    learn_kubernetes
 weight: 50
+canonical: 'https://www.checklyhq.com/docs/learn/kubernetes/structured-logging/'
 ---
 
 For developers and administrators, adopting structured logging means enhancing observability, streamlining log analysis, and improved system performance. In this post we’ll cover the fundamentals of structured logging in Kubernetes, its practical applications, and best practices for implementing it in your systems.

--- a/learn/monitoring/api-monitoring.mdx
+++ b/learn/monitoring/api-monitoring.mdx
@@ -11,6 +11,7 @@ displayDescription:
 learn_monitoring:
   parent: Monitoring Concepts
 weight: 35
+canonical: 'https://www.checklyhq.com/docs/learn/monitoring/api-monitoring/'
 ---
 
 API monitoring is the practice of evaluating how an API (Application Programming Interface) is performing over time via several different metrics, including verifying availability, verifying correctness (i.e., is the data that is being sent and received correctly?), and measuring performance and asserting that against a performance threshold. The goal is to determine whether the APIs are functioning as they should and whether they are available and functioning at an optimal level for the other applications and services that rely on them.

--- a/learn/monitoring/frontend-monitoring.mdx
+++ b/learn/monitoring/frontend-monitoring.mdx
@@ -11,6 +11,7 @@ displayDescription:
 learn_monitoring:
   parent: Monitoring Concepts
 weight: 70
+canonical: 'https://www.checklyhq.com/docs/learn/monitoring/frontend-monitoring/'
 ---
 
 No matter what internal testing or error monitoring we do for our web services, our end users will interact with that service through a front end. It’s necessary to perform front end monitoring so that you’re not relying on users to report problems.

--- a/learn/monitoring/https-for-app-developers.mdx
+++ b/learn/monitoring/https-for-app-developers.mdx
@@ -11,6 +11,7 @@ displayDescription: Understanding the basics of HTTPS can help you build better,
 weight: 190
 learn_monitoring:
       parent: Protocols
+canonical: 'https://www.checklyhq.com/docs/learn/monitoring/https-for-app-developers/'
 ---
 **HTTPS Fundamentals for Application Developers**
 

--- a/learn/monitoring/metrics-every-team-needs.mdx
+++ b/learn/monitoring/metrics-every-team-needs.mdx
@@ -11,6 +11,7 @@ displayDescription:
 learn_monitoring:
   parent: Observability Basics
 weight: 20
+canonical: 'https://www.checklyhq.com/docs/learn/monitoring/metrics-every-team-needs/'
 ---
 
 When you begin implementing observability beyond basic logging, you’ll be presented with a large number of tools that promise the ability to give insight into every aspect of your application. But when we consider observing every possible running line of code and service worker stats, we quickly find ourselves going from almost no information to information overload. Rather than trying to observe everything, it’s better to start with a minimum viable product, and this article will help define the metrics that every team needs to get tracking of their system’s performance.

--- a/learn/monitoring/tcp-and-ssl.mdx
+++ b/learn/monitoring/tcp-and-ssl.mdx
@@ -10,6 +10,7 @@ sidebarTitle:  TCP and SSL
 weight: 100
 learn_monitoring:
       parent: Protocols
+canonical: 'https://www.checklyhq.com/docs/learn/monitoring/tcp-and-ssl/'
 ---
 
 

--- a/learn/monitoring/web-application-monitoring.mdx
+++ b/learn/monitoring/web-application-monitoring.mdx
@@ -10,6 +10,7 @@ displayDescription: Explore web application monitoring to boost performance and 
 learn_monitoring:
   parent: Monitoring Concepts
 weight: 31
+canonical: 'https://www.checklyhq.com/docs/learn/monitoring/web-application-monitoring/'
 ---
 
 Web application monitoring refers to the practice of observing, tracking, and managing the performance, availability, and reliability of web applications. It ensures users have a seamless experience and minimizes disruptions by identifying issues in real-time. All that’s required for something to be a ‘web application’ is that it’s more than a static site, and that it takes requests via the internet. Even an API mainly accessed via TCP is a web application!

--- a/learn/monitoring/what-is-tcp.mdx
+++ b/learn/monitoring/what-is-tcp.mdx
@@ -11,6 +11,7 @@ displayDescription: Understanding the basics of TCP can help you build better, m
 weight: 90
 learn_monitoring:
       parent: Protocols
+canonical: 'https://www.checklyhq.com/docs/learn/monitoring/what-is-tcp/'
 ---
 
 As an application developer, you might think that Transmission Control Protocol (TCP) is something only network engineers need to worry about. However, as application developers take on more of the operational design and running of their applications, these previously 'low level' protocols come to the fore. Understanding the basics of TCP can help you build better, more reliable applications. This document will explain what TCP is, how it works, and what you need to know as an application developer.

--- a/learn/playwright/codegen.mdx
+++ b/learn/playwright/codegen.mdx
@@ -11,6 +11,7 @@ weight: 40
 sidebarTitle: Codegen
 learn_playwright:
   parent: "Basics"
+canonical: 'https://www.checklyhq.com/docs/learn/playwright/codegen/'
 ---
 
 import PlaywrightCheckSuiteTryOut from "/snippets/playwright-check-suite-tryout.mdx"

--- a/learn/playwright/emulating-mobile-devices.mdx
+++ b/learn/playwright/emulating-mobile-devices.mdx
@@ -15,6 +15,7 @@ weight: 130
 
 learn_playwright:
   parent: "Basics"
+canonical: 'https://www.checklyhq.com/docs/learn/playwright/emulating-mobile-devices/'
 ---
 
 import SignUpCta from "/snippets/sign-up-cta.mdx"

--- a/learn/playwright/waits-and-timeouts.mdx
+++ b/learn/playwright/waits-and-timeouts.mdx
@@ -10,6 +10,7 @@ sidebarTitle: Waits and timeouts
 weight: 70
 learn_playwright:
   parent: "Interaction"
+canonical: 'https://www.checklyhq.com/docs/learn/playwright/waits-and-timeouts/'
 ---
 
 import PlaywrightCheckSuiteTryOut from "/snippets/playwright-check-suite-tryout.mdx"

--- a/learn/playwright/what-is-playwright.mdx
+++ b/learn/playwright/what-is-playwright.mdx
@@ -14,6 +14,7 @@ aliases:
   - /learn/playwright/getting-started/
 learn_playwright:
   parent: "Getting started"
+canonical: 'https://www.checklyhq.com/docs/learn/playwright/what-is-playwright/'
 ---
 
 import PlaywrightCheckSuiteTryOut from "/snippets/playwright-check-suite-tryout.mdx"


### PR DESCRIPTION
## Trailing-slash canonical experiment (20 pages) + canonical base fix

A/B-style test: give the **20 top docs pages** an explicit trailing-slash canonical and leave everything else on the auto-generated no-slash canonical as a control. Evaluate in ~3 weeks (**~2026-07-27**).

### Baseline fix (commit 1) — supersedes #421
- `docs.json` `seo.metatags.canonical` → `https://www.checklyhq.com/docs` (the bare origin was dropping the `/docs` mount, emitting `checklyhq.com/detect/overview`).
- Removed the temporary probe canonical from `cli/overview.mdx` so it rejoins the control.
- **Result:** every non-experiment page emits `www + /docs + no-slash` — the control baseline.

### The experiment (commit 2)
20 pages get a per-page `canonical:` equal to their own served URL (`www + /docs + trailing slash`). Chosen by keyword coverage (organic traffic is ~0 across docs, so keywords is the best "importance" proxy):

| # | Page |
|---|------|
| 1 | learn/monitoring/tcp-and-ssl |
| 2 | detect/uptime-monitoring/tcp-monitors/overview |
| 3 | learn/playwright/what-is-playwright |
| 4 | learn/monitoring/what-is-tcp |
| 5 | learn/monitoring/web-application-monitoring |
| 6 | learn/playwright/waits-and-timeouts |
| 7 | learn/incidents/slo-sla-sli |
| 8 | comparisons/frameworks/playwright-vs-cypress |
| 9 | learn/monitoring/api-monitoring |
| 10 | detect/synthetic-monitoring/api-checks/overview |
| 11 | integrations/alerts/telegram |
| 12 | guides/end-to-end-monitoring |
| 13 | learn/playwright/emulating-mobile-devices |
| 14 | guides/auto-waiting-methods |
| 15 | learn/monitoring/frontend-monitoring |
| 16 | learn/kubernetes/structured-logging |
| 17 | learn/monitoring/metrics-every-team-needs |
| 18 | learn/monitoring/https-for-app-developers |
| 19 | learn/kubernetes/monitoring-challenges |
| 20 | learn/playwright/codegen |

### How to evaluate (~2026-07-27)
Primary signal is **how Google canonicalizes/indexes** the test pages, not traffic (docs traffic is tiny):
- **GSC → Page indexing / URL Inspection:** for the 20, does Google now report "User-declared canonical" = the trailing-slash URL and index it cleanly? Does the "non-canonical page receives organic traffic" / duplicate signal clear vs. the control?
- **Impressions / clicks / position** trend for the 20 vs. control (directional only).
- **Ahrefs** re-crawl: do the 20 stop showing the canonical-to-redirect flag?

If the trailing-slash pages behave better (or the same with cleaner signals), roll out per-page canonicals more broadly; if no difference, the `docs.json` no-slash baseline stands on its own and we skip the per-page maintenance.

Verified: `docs.json` valid, all 20 frontmatter blocks parse, `mint broken-links` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
