### PR TITLE
Fix docs home canonical + add home to sitemap

### DIFF
--- a/.github/scripts/generate-sitemap.mjs
+++ b/.github/scripts/generate-sitemap.mjs
@@ -47,9 +47,11 @@ function walk(node) {
 }
 walk(docs.navigation)
 
-const urls = [...slugs]
-  .sort()
-  .map((slug) => `  <url>\n    <loc>${BASE}${slug}/</loc>\n  </url>`)
+// The docs home (index.mdx) is served at /docs/ but is not a nav slug, so add
+// it explicitly — otherwise the homepage is missing from the sitemap.
+const locs = [BASE, ...[...slugs].sort().map((slug) => `${BASE}${slug}/`)]
+const urls = locs
+  .map((loc) => `  <url>\n    <loc>${loc}</loc>\n  </url>`)
   .join('\n')
 
 const xml = `<?xml version="1.0" encoding="UTF-8"?>
@@ -59,4 +61,4 @@ ${urls}
 `
 
 writeFileSync(join(ROOT, 'sitemap.xml'), xml)
-console.log(`Wrote sitemap.xml with ${slugs.size} trailing-slash URLs`)
+console.log(`Wrote sitemap.xml with ${locs.length} trailing-slash URLs (incl. home)`)

--- a/changelog/changelog.mdx
+++ b/changelog/changelog.mdx
@@ -2,6 +2,7 @@
 title: Changelog
 sidebarTitle: Changelog
 description: Stay up to date with product updates and release notes across Checkly.
+canonical: 'https://www.checklyhq.com/docs/changelog/changelog/'
 ---
 
 ## Available Changelogs

--- a/communicate/alerts/best-practices.mdx
+++ b/communicate/alerts/best-practices.mdx
@@ -2,6 +2,7 @@
 title: 'Alerting Best Practices'
 description: 'Proven strategies and patterns for effective alerting, incident response, and alert fatigue prevention in Checkly monitoring implementations.'
 sidebarTitle: 'Best Practices'
+canonical: 'https://www.checklyhq.com/docs/communicate/alerts/best-practices/'
 ---
 
 

--- a/comparisons/monitoring-tools/overview.mdx
+++ b/comparisons/monitoring-tools/overview.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Monitoring Tools Overview"
 description: "Compare Checkly with popular monitoring and APM solutions"
+canonical: 'https://www.checklyhq.com/docs/comparisons/monitoring-tools/overview/'
 ---
 
 # Monitoring Tools Overview

--- a/comparisons/observability-tools/overview.mdx
+++ b/comparisons/observability-tools/overview.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Observability Tools Overview"
 description: "Compare Checkly with popular observability and tracing platforms"
+canonical: 'https://www.checklyhq.com/docs/comparisons/observability-tools/overview/'
 ---
 
 # Observability Tools Overview

--- a/comparisons/overview.mdx
+++ b/comparisons/overview.mdx
@@ -2,6 +2,7 @@
 title: 'Comparisons Overview'
 description: 'Display inline code and code blocks'
 sidebarTitle: 'Overview'
+canonical: 'https://www.checklyhq.com/docs/comparisons/overview/'
 ---
 
 

--- a/comparisons/status-pages/overview.mdx
+++ b/comparisons/status-pages/overview.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Status Pages Overview"
 description: "Compare Checkly status pages with other status page solutions"
+canonical: 'https://www.checklyhq.com/docs/comparisons/status-pages/overview/'
 ---
 
 # Status Pages Overview

--- a/comparisons/testing-tools/overview.mdx
+++ b/comparisons/testing-tools/overview.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Testing Tools Overview"
 description: "Compare Checkly with popular testing frameworks and tools"
+canonical: 'https://www.checklyhq.com/docs/comparisons/testing-tools/overview/'
 ---
 
 # Testing Tools Overview

--- a/concepts/environments.mdx
+++ b/concepts/environments.mdx
@@ -2,6 +2,7 @@
 title: 'Environments in Checkly'
 description: 'Learn about the environments of Checkly'
 sidebarTitle: 'Environments'
+canonical: 'https://www.checklyhq.com/docs/concepts/environments/'
 ---
 
 **Environments** in Checkly represent the different stages and contexts where your applications run—from development and staging to production and beyond. Using the CLI, you can run your commands from your CI/CD pipeline and target different environments like staging and production.

--- a/concepts/monitors.mdx
+++ b/concepts/monitors.mdx
@@ -2,6 +2,7 @@
 title: 'What are Monitors?'
 description: 'Learn about Uptime Monitors at Checkly'
 sidebarTitle: 'Monitors'
+canonical: 'https://www.checklyhq.com/docs/concepts/monitors/'
 ---
 
 

--- a/concepts/overview.mdx
+++ b/concepts/overview.mdx
@@ -2,6 +2,7 @@
 title: 'Core Concepts Overview'
 description: 'Learn about the core concepts of Checkly'
 sidebarTitle: 'Overview'
+canonical: 'https://www.checklyhq.com/docs/concepts/overview/'
 ---
 
 Organization in Checkly refers to how you structure and manage your monitoring setup through Groups and hierarchical organization. Groups allow you to organize your checks and centralize settings like base URLs, headers, variables and other properties a collection of checks can share. 

--- a/detect/synthetic-monitoring/api-checks/best-practices.mdx
+++ b/detect/synthetic-monitoring/api-checks/best-practices.mdx
@@ -2,6 +2,7 @@
 title: 'API Check Best Practices'
 description: 'Proven strategies, optimization techniques, and reliability patterns for implementing effective API monitoring with Checkly.'
 sidebarTitle: 'Best Practices'
+canonical: 'https://www.checklyhq.com/docs/detect/synthetic-monitoring/api-checks/best-practices/'
 ---
 
 Effective API monitoring requires thoughtful design, proper configuration, and ongoing optimization. These best practices ensure reliable, efficient, and maintainable API checks that provide actionable insights.

--- a/detect/synthetic-monitoring/api-checks/examples.mdx
+++ b/detect/synthetic-monitoring/api-checks/examples.mdx
@@ -2,6 +2,7 @@
 title: 'API Check Examples'
 description: 'Real-world examples and implementation patterns for monitoring APIs with Checkly API checks across different industries and scenarios.'
 sidebarTitle: 'Examples'
+canonical: 'https://www.checklyhq.com/docs/detect/synthetic-monitoring/api-checks/examples/'
 ---
 
 API checks excel at validating backend services, microservices, and third-party integrations. These real-world use cases demonstrate how to implement comprehensive API monitoring across different industries and scenarios.

--- a/detect/synthetic-monitoring/api-checks/response-limits.mdx
+++ b/detect/synthetic-monitoring/api-checks/response-limits.mdx
@@ -1,6 +1,7 @@
 ---
 title: API Response time limits
 sidebarTitle: Response time limits
+canonical: 'https://www.checklyhq.com/docs/detect/synthetic-monitoring/api-checks/response-limits/'
 ---
 
 

--- a/detect/synthetic-monitoring/browser-checks/best-practices.mdx
+++ b/detect/synthetic-monitoring/browser-checks/best-practices.mdx
@@ -2,6 +2,7 @@
 title: 'Browser Check Best Practices'
 description: 'Proven strategies, optimization techniques, and reliability patterns for implementing effective browser automation monitoring with Checkly.'
 sidebarTitle: 'Best Practices'
+canonical: 'https://www.checklyhq.com/docs/detect/synthetic-monitoring/browser-checks/best-practices/'
 ---
 
 Effective browser monitoring requires thoughtful test design, reliable selectors, and robust error handling. These best practices ensure your browser checks are maintainable, reliable, and provide actionable insights about user experience.

--- a/detect/synthetic-monitoring/browser-checks/examples.mdx
+++ b/detect/synthetic-monitoring/browser-checks/examples.mdx
@@ -2,6 +2,7 @@
 title: 'Browser Check Examples'
 description: 'Real-world examples and implementation patterns for monitoring user workflows with Checkly browser checks across different industries and scenarios.'
 sidebarTitle: 'Examples'
+canonical: 'https://www.checklyhq.com/docs/detect/synthetic-monitoring/browser-checks/examples/'
 ---
 
 These real-world use cases demonstrate how to implement comprehensive user journey monitoring across different industries and scenarios.

--- a/detect/synthetic-monitoring/browser-checks/file-system.mdx
+++ b/detect/synthetic-monitoring/browser-checks/file-system.mdx
@@ -2,6 +2,7 @@
 title: File uploads, downloads and the file system
 sidebarTitle: File system
 
+canonical: 'https://www.checklyhq.com/docs/detect/synthetic-monitoring/browser-checks/file-system/'
 ---
 
 You might want to use (binary) files in your browser checks. For example, you might want to upload a file to an upload 

--- a/detect/synthetic-monitoring/multistep-checks/troubleshooting.mdx
+++ b/detect/synthetic-monitoring/multistep-checks/troubleshooting.mdx
@@ -3,6 +3,7 @@
 title: 'Troubleshooting Multistep Checks'
 description: 'Learn how to troubleshoot multistep checks.'
 sidebarTitle: Troubleshooting
+canonical: 'https://www.checklyhq.com/docs/detect/synthetic-monitoring/multistep-checks/troubleshooting/'
 ---
 
 Multistep checks are a powerful tool for monitoring complex API workflows. However, they can sometimes be tricky to troubleshoot. Here are some common issues and solutions:

--- a/detect/uptime-monitoring/alerting.mdx
+++ b/detect/uptime-monitoring/alerting.mdx
@@ -2,6 +2,7 @@
 title: 'Alerting Configuration'
 description: 'Configure comprehensive alerting for your uptime monitors to ensure your team is immediately notified when issues occur.'
 sidebarTitle: 'Alerting'
+canonical: 'https://www.checklyhq.com/docs/detect/uptime-monitoring/alerting/'
 ---
 
 Effective alerting is crucial for maintaining service reliability. This guide covers how to configure alerting for all types of uptime monitors to ensure your team responds quickly to issues.

--- a/detect/uptime-monitoring/cli-configuration.mdx
+++ b/detect/uptime-monitoring/cli-configuration.mdx
@@ -2,6 +2,7 @@
 title: 'CLI Configuration'
 description: 'Define and manage uptime monitors as code using the Checkly CLI with TypeScript and JavaScript examples.'
 sidebarTitle: 'CLI Configuration'
+canonical: 'https://www.checklyhq.com/docs/detect/uptime-monitoring/cli-configuration/'
 ---
 
 The Checkly CLI enables you to define, version control, and deploy uptime monitors as code. This approach provides better maintainability, team collaboration, and integration with your development workflow.

--- a/detect/uptime-monitoring/heartbeat-monitors/ci-cd-configuration.mdx
+++ b/detect/uptime-monitoring/heartbeat-monitors/ci-cd-configuration.mdx
@@ -2,6 +2,7 @@
 title: 'CI/CD Configuration'
 description: 'Learn how to configure heartbeat monitors with CI/CD.'
 sidebarTitle: CI/CD
+canonical: 'https://www.checklyhq.com/docs/detect/uptime-monitoring/heartbeat-monitors/ci-cd-configuration/'
 ---
 
 

--- a/detect/uptime-monitoring/heartbeat-monitors/cli-configuration.mdx
+++ b/detect/uptime-monitoring/heartbeat-monitors/cli-configuration.mdx
@@ -2,6 +2,7 @@
 title: 'CLI Configuration'
 description: 'Learn how to configure heartbeat monitors with the Checkly CLI.'
 sidebarTitle: CLI
+canonical: 'https://www.checklyhq.com/docs/detect/uptime-monitoring/heartbeat-monitors/cli-configuration/'
 ---
 
 

--- a/detect/uptime-monitoring/heartbeat-monitors/configuration.mdx
+++ b/detect/uptime-monitoring/heartbeat-monitors/configuration.mdx
@@ -2,6 +2,7 @@
 title: Heartbeat Configuration
 description:  Ensure your critical automated processes are running as expected.
 sidebarTitle: Configuration
+canonical: 'https://www.checklyhq.com/docs/detect/uptime-monitoring/heartbeat-monitors/configuration/'
 ---
 
 ### Additional Settings

--- a/detect/uptime-monitoring/heartbeat-monitors/cron-configuration.mdx
+++ b/detect/uptime-monitoring/heartbeat-monitors/cron-configuration.mdx
@@ -2,6 +2,7 @@
 title: 'Cron Jobs Configuration'
 description: 'Learn how to configure heartbeat monitors with cron jobs.'
 sidebarTitle: Cron Jobs
+canonical: 'https://www.checklyhq.com/docs/detect/uptime-monitoring/heartbeat-monitors/cron-configuration/'
 ---
 
 ## With Scheduled Jobs and Cron

--- a/detect/uptime-monitoring/heartbeat-monitors/iac-configuration.mdx
+++ b/detect/uptime-monitoring/heartbeat-monitors/iac-configuration.mdx
@@ -2,6 +2,7 @@
 title: 'Infrastructure as Code Configuration'
 description: 'Learn how to configure heartbeat monitors with Infrastructure as Code.'
 sidebarTitle: Infrastructure as Code
+canonical: 'https://www.checklyhq.com/docs/detect/uptime-monitoring/heartbeat-monitors/iac-configuration/'
 ---
 
 

--- a/detect/uptime-monitoring/heartbeat-monitors/other.mdx
+++ b/detect/uptime-monitoring/heartbeat-monitors/other.mdx
@@ -2,6 +2,7 @@
 title: 'Other Configurations'
 description: 'Learn how to configure heartbeat monitors with other tools and platforms.'
 sidebarTitle: Other Configurations
+canonical: 'https://www.checklyhq.com/docs/detect/uptime-monitoring/heartbeat-monitors/other/'
 ---
 
 

--- a/detect/uptime-monitoring/locations.mdx
+++ b/detect/uptime-monitoring/locations.mdx
@@ -2,6 +2,7 @@
 title: 'Monitoring Locations'
 description: 'Choose optimal monitoring locations for global coverage and accurate performance insights across all monitor types.'
 sidebarTitle: 'Locations'
+canonical: 'https://www.checklyhq.com/docs/detect/uptime-monitoring/locations/'
 ---
 
 Selecting the right monitoring locations ensures accurate uptime monitoring and provides insights into your service's global performance. This guide applies to URL, TCP, and Heartbeat monitors.

--- a/detect/uptime-monitoring/scheduling.mdx
+++ b/detect/uptime-monitoring/scheduling.mdx
@@ -2,6 +2,7 @@
 title: 'Scheduling and Frequency'
 description: 'Configure optimal monitoring frequency and timing strategies for different types of uptime monitors.'
 sidebarTitle: 'Scheduling'
+canonical: 'https://www.checklyhq.com/docs/detect/uptime-monitoring/scheduling/'
 ---
 
 Proper scheduling ensures effective monitoring while balancing detection speed, resource usage, and costs. This guide covers scheduling strategies for all monitor types.

--- a/index.mdx
+++ b/index.mdx
@@ -2,6 +2,7 @@
 title: 'Checkly Documentation'
 description: 'The AI Native Application Reliability Platform built for modern engineering teams.'
 mode: "wide"
+canonical: 'https://www.checklyhq.com/docs/'
 
 ---
 

--- a/integrations/alerts/overview.mdx
+++ b/integrations/alerts/overview.mdx
@@ -2,6 +2,7 @@
 title: 'Alerts'
 description: 'Alerts'
 sidebarTitle: 'Overview'
+canonical: 'https://www.checklyhq.com/docs/integrations/alerts/overview/'
 ---
 
 This is the alerts overview.

--- a/integrations/iac/pulumi/examples.mdx
+++ b/integrations/iac/pulumi/examples.mdx
@@ -2,6 +2,7 @@
 title: 'Pulumi Examples'
 description: 'Comprehensive examples for different check types and configurations using the Checkly Pulumi provider'
 sidebarTitle: 'Examples'
+canonical: 'https://www.checklyhq.com/docs/integrations/iac/pulumi/examples/'
 ---
 
 

--- a/integrations/iac/terraform/checks-groups.mdx
+++ b/integrations/iac/terraform/checks-groups.mdx
@@ -2,6 +2,7 @@
 title: 'Checks and groups for Terraform'
 sidebarTitle: 'Checks & Groups'
 description: 'Create and manage browser checks, API checks, heartbeat monitors, and check groups using Terraform'
+canonical: 'https://www.checklyhq.com/docs/integrations/iac/terraform/checks-groups/'
 ---
 
 Checks make up the most important unit of your Checkly monitoring setup. Groups help you split them up according to your needs and keep complexity down.

--- a/integrations/iac/terraform/parameterized-resources.mdx
+++ b/integrations/iac/terraform/parameterized-resources.mdx
@@ -2,6 +2,7 @@
 title: 'Parameterized resources in Terraform'
 sidebarTitle: 'Parameterized Resources'
 description: 'Use Terraform meta-arguments to create multiple resources from parameterized configurations'
+canonical: 'https://www.checklyhq.com/docs/integrations/iac/terraform/parameterized-resources/'
 ---
 
 There are cases where you might want to declare a single, parameterized resource in place of a (possibly variable) number of resources to be managed. Terraform enables this through some of its native constructs.

--- a/learn/overview.mdx
+++ b/learn/overview.mdx
@@ -2,6 +2,7 @@
 title: "Learn Concepts and Best Practices"
 sidebarTitle: "Overview"
 mode: "wide"
+canonical: 'https://www.checklyhq.com/docs/learn/overview/'
 ---
 
 Monitoring and Observability are key concepts when dealing with application quality and performance. Learn the fundamentals of modern monitoring and observability to help yourself and your team build better applications.

--- a/platform/snippets/handlebars-snippets.mdx
+++ b/platform/snippets/handlebars-snippets.mdx
@@ -1,6 +1,7 @@
 ---
 title: Handlebars Snippets (Legacy)
 sidebarTitle: Snippets (Legacy)
+canonical: 'https://www.checklyhq.com/docs/platform/snippets/handlebars-snippets/'
 ---
 
 > We still support our legacy Handlebars syntax for referencing snippets in Browser check code but recommend using the **require**

--- a/platform/snippets/overview.mdx
+++ b/platform/snippets/overview.mdx
@@ -1,6 +1,7 @@
 ---
 title: Snippets Overview
 sidebarTitle: Snippets
+canonical: 'https://www.checklyhq.com/docs/platform/snippets/overview/'
 ---
 
 import { CLITip } from "/snippets/cli-tip.jsx"

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
+    <loc>https://www.checklyhq.com/docs/</loc>
+  </url>
+  <url>
     <loc>https://www.checklyhq.com/docs/admin/changing-your-email-password/</loc>
   </url>
   <url>


### PR DESCRIPTION
The docs home (`index.mdx`, served at `/docs/`) was the one page missed by the canonical rollout, because it is not a `docs.json` nav entry — so it fell back to the global base and emitted `<link rel=\"canonical\" href=\"https://www.checklyhq.com/docs\">` (no trailing slash), mismatching the served `/docs/` URL. An SEO extension flagged it as "canonicalised away / not indexable."

## Fixes
- `index.mdx`: add `canonical: 'https://www.checklyhq.com/docs/'` (self-referencing).
- `.github/scripts/generate-sitemap.mjs`: include the home URL (`/docs/`) — it was absent from the sitemap since it is not a nav slug. Sitemap is now 570 URLs.

## Notes
- The `X-Robots-Tag: noindex` an extension may show on the home is NOT present on the live www response (verified: no robots header on `www.checklyhq.com/docs/` or the bare-domain 301). That reading is stale/preview; the real issue was only the canonical mismatch, which this fixes.
- Verified: valid XML, drift check clean, canonical now self-references `/docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)