### PR TITLE
docs(api-checks): document text-body assertion opt-out from binary scrubbing

### DIFF
--- a/detect/synthetic-monitoring/api-checks/configuration.mdx
+++ b/detect/synthetic-monitoring/api-checks/configuration.mdx
@@ -215,6 +215,14 @@ This list shows all content types that we scrub from the response data.
 |`video/x-flv`|
 |`video/webm`|
 
+### Asserting on binary response bodies
+
+Adding a **Text body** assertion to a check opts it out of binary scrubbing entirely: the assertion runs against
+the real response bytes, and the stored result displays those same bytes instead of the scrubbed message. This is
+useful when a server labels a textual payload with a binary content type, such as `application/octet-stream`. The
+assertion's *Actual* value is truncated to 10KB for display, and stored response bodies remain subject to the size
+limits above. Checks without a Text body assertion keep the scrubbing behavior described in this section.
+
 ## Additional Settings
 
 * **Name:** Give your check a clear name to identify it in dashboards and alerts


### PR DESCRIPTION
## What

Adds an **"Asserting on binary response bodies"** subsection to the API checks configuration page, directly under the existing binary-scrubbing section and its content-type table.

Documents the new runner behavior from checkly/monorepo#2883: adding a **Text body** assertion opts a check out of binary scrubbing entirely — the assertion runs against the real response bytes and the stored result displays those same bytes. Covers the motivating case (a textual payload mislabelled as `application/octet-stream` that the customer can't change), the 10KB truncation of the assertion's *Actual* value, and that checks without a Text body assertion keep today's scrubbing behavior.

Requested by Sergii during review of the runner PR.

## When to merge

The behavior lands with the next go-runner release (checkly/monorepo#2883, approved pending ship) — hold or time this accordingly.
