### PR TITLE
docs: add frontmatter descriptions to 71 pages for AEO

### DIFF
--- a/cli/attaching-git-metadata.mdx
+++ b/cli/attaching-git-metadata.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Attaching Git metadata'
+description: "Attach git metadata like branch, commit SHA, and owner to your Checkly test sessions and deployments so you can cross-reference monitoring with code changes."
 sidebarTitle: 'Attaching Git Metadata'
 canonical: 'https://www.checklyhq.com/docs/cli/attaching-git-metadata/'
 ---

--- a/cli/dependencies.mdx
+++ b/cli/dependencies.mdx
@@ -1,5 +1,6 @@
 ---
 title: Using npm packages and local dependencies
+description: "Use npm packages and local JavaScript or TypeScript files in your checks, and see how dependencies differ between Checkly runtimes and Playwright Check Suites."
 sidebarTitle: npm & Local Dependencies
 canonical: 'https://www.checklyhq.com/docs/cli/dependencies/'
 ---

--- a/communicate/alerts/notification-log.mdx
+++ b/communicate/alerts/notification-log.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Alert Notification Log'
+description: "Browse and filter the Alert Notification Log to troubleshoot failed alert deliveries, inspect status codes, and see the exact configuration used per channel."
 sidebarTitle: 'Notification Log'
 canonical: 'https://www.checklyhq.com/docs/communicate/alerts/notification-log/'
 ---

--- a/communicate/alerts/retries.mdx
+++ b/communicate/alerts/retries.mdx
@@ -1,6 +1,7 @@
 ---
 
 title: 'Alert Retries'
+description: "Use retries to guard against flaky failures and alert fatigue, choosing between scheduled retry strategies for checks, check groups, and test sessions."
 sidebarTitle: 'Retries'
 canonical: 'https://www.checklyhq.com/docs/communicate/alerts/retries/'
 ---

--- a/communicate/alerts/ssl-expiration.mdx
+++ b/communicate/alerts/ssl-expiration.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'SSL Certificate Expiration Alerts'
+description: "Get alerted up to 30 days before an SSL certificate expires. Checkly checks your certificate hourly and can notify any alert channel at your chosen threshold."
 sidebarTitle: 'SSL Alerts'
 canonical: 'https://www.checklyhq.com/docs/communicate/alerts/ssl-expiration/'
 ---

--- a/communicate/dashboards/custom-css.mdx
+++ b/communicate/dashboards/custom-css.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Customizing Your Dashboard with CSS'
+description: "Match a Checkly dashboard to your company branding with custom CSS rules, edited directly in the Look & Feel section of the dashboard settings."
 sidebarTitle: 'Custom CSS'
 canonical: 'https://www.checklyhq.com/docs/communicate/dashboards/custom-css/'
 ---

--- a/communicate/dashboards/incidents.mdx
+++ b/communicate/dashboards/incidents.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Incident & Maintenance messages'
+description: "Communicate outages and planned maintenance to your audience by publishing incidents on a Checkly dashboard, turning it into a status page."
 sidebarTitle: 'Incidents'
 canonical: 'https://www.checklyhq.com/docs/communicate/dashboards/incidents/'
 ---

--- a/constructs/dynamic-monitor-creation.mdx
+++ b/constructs/dynamic-monitor-creation.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Dynamic monitor creation'
+description: "Create monitors dynamically with the Checkly CLI by looping over lists of targets in TypeScript or JavaScript, managing checks at scale without duplication."
 sidebarTitle: 'Dynamic Monitor Creation'
 canonical: 'https://www.checklyhq.com/docs/constructs/dynamic-monitor-creation/'
 ---

--- a/detect/synthetic-monitoring/api-checks/client-certificates.mdx
+++ b/detect/synthetic-monitoring/api-checks/client-certificates.mdx
@@ -1,5 +1,6 @@
 ---
 title: Client certificates
+description: "Authenticate API checks against APIs that require mutual TLS (mTLS) by adding client certificates, private keys, and a CA per domain on the Enterprise plan."
 sidebarTitle: Client Certificates
 canonical: 'https://www.checklyhq.com/docs/detect/synthetic-monitoring/api-checks/client-certificates/'
 ---

--- a/detect/synthetic-monitoring/api-checks/response-limits.mdx
+++ b/detect/synthetic-monitoring/api-checks/response-limits.mdx
@@ -1,5 +1,6 @@
 ---
 title: API Response time limits
+description: "Set degraded and failing response-time thresholds for API checks so slow-but-working APIs are flagged before they break, without hurting your success ratio."
 sidebarTitle: Response time limits
 canonical: 'https://www.checklyhq.com/docs/detect/synthetic-monitoring/api-checks/response-limits/'
 ---

--- a/detect/synthetic-monitoring/browser-checks/file-system.mdx
+++ b/detect/synthetic-monitoring/browser-checks/file-system.mdx
@@ -1,5 +1,6 @@
 ---
 title: File uploads, downloads and the file system
+description: "Handle file uploads and downloads in browser checks using Playwright's download event, the Download object, and setInputFiles to validate files end to end."
 sidebarTitle: File system
 
 canonical: 'https://www.checklyhq.com/docs/detect/synthetic-monitoring/browser-checks/file-system/'

--- a/detect/synthetic-monitoring/browser-checks/playwright-support.mdx
+++ b/detect/synthetic-monitoring/browser-checks/playwright-support.mdx
@@ -1,5 +1,6 @@
 ---
 title: Playwright Support in Checkly
+description: "See which Playwright features Checkly's browser checks support, from trace files and video recordings to auto-waiting, locators, and visual regression testing."
 sidebarTitle: 'Playwright Support'
 canonical: 'https://www.checklyhq.com/docs/detect/synthetic-monitoring/browser-checks/playwright-support/'
 ---

--- a/detect/synthetic-monitoring/multistep-checks/degraded-states.mdx
+++ b/detect/synthetic-monitoring/multistep-checks/degraded-states.mdx
@@ -1,5 +1,6 @@
 ---
 title: Degraded States In Multistep Checks
+description: "Signal non-critical slowdowns in multistep checks with the degraded state, using soft assertions and the @checkly/playwright-helpers markCheckAsDegraded helper."
 sidebarTitle: Degraded States
 
 canonical: 'https://www.checklyhq.com/docs/detect/synthetic-monitoring/multistep-checks/degraded-states/'

--- a/detect/synthetic-monitoring/multistep-checks/file-system.mdx
+++ b/detect/synthetic-monitoring/multistep-checks/file-system.mdx
@@ -1,5 +1,6 @@
 ---
 title: Uploading & Downloading Files To The File System
+description: "Upload and download binary files in multistep checks with Playwright's request object, hosting files externally and validating them with HTTP requests."
 sidebarTitle: File System
 
 canonical: 'https://www.checklyhq.com/docs/detect/synthetic-monitoring/multistep-checks/file-system/'

--- a/detect/synthetic-monitoring/multistep-checks/websockets.mdx
+++ b/detect/synthetic-monitoring/multistep-checks/websockets.mdx
@@ -1,5 +1,6 @@
 ---
 title: WebSockets on Multistep checks - Checkly Docs
+description: "Monitor a WebSocket endpoint from a multistep check by scripting a connection, sending messages, and validating the responses you get back."
 sidebarTitle: WebSockets
 navTitle: WebSockets
 

--- a/detect/testing/using-env-variables.mdx
+++ b/detect/testing/using-env-variables.mdx
@@ -1,5 +1,6 @@
 ---
 title: Using Environment Variables
+description: "Pass environment variables to your Checkly tests so a single check can run against staging, preview, or production URLs using the --env flag."
 sidebarTitle: Environment Variables
 canonical: 'https://www.checklyhq.com/docs/detect/testing/using-env-variables/'
 ---

--- a/integrations/ci-cd/github/actions.mdx
+++ b/integrations/ci-cd/github/actions.mdx
@@ -1,5 +1,6 @@
 ---
 title: Integrating Checkly in GitHub Actions
+description: "Run Checkly checks from GitHub Actions, triggering on deployment_status or push events to validate deployments before promoting your checks to monitors."
 sidebarTitle: GitHub Actions
 canonical: 'https://www.checklyhq.com/docs/integrations/ci-cd/github/actions/'
 ---

--- a/integrations/ci-cd/github/deployments.mdx
+++ b/integrations/ci-cd/github/deployments.mdx
@@ -1,5 +1,6 @@
 ---
 title: Integrating Checkly in GitHub Deployments
+description: "Trigger Checkly checks from GitHub deployment events fired by services like Vercel and Heroku, running against both preview and production deployments."
 sidebarTitle: GitHub Deployments
 canonical: 'https://www.checklyhq.com/docs/integrations/ci-cd/github/deployments/'
 ---

--- a/integrations/ci-cd/gitlab/overview.mdx
+++ b/integrations/ci-cd/gitlab/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Integrating Checkly in GitLab CI/CD
+description: "Run and deploy Checkly checks from a GitLab CI/CD pipeline, using a branch-aware setup that only promotes checks to monitors after they pass against production."
 sidebarTitle: GitLab
 canonical: 'https://www.checklyhq.com/docs/integrations/ci-cd/gitlab/overview/'
 ---

--- a/integrations/ci-cd/jenkins/overview.mdx
+++ b/integrations/ci-cd/jenkins/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Integrating Checkly in Jenkins
+description: "Run the Checkly CLI from a Jenkins pipeline, setting API credentials, choosing a reporter, and deploying checks as monitors after they pass against production."
 sidebarTitle: Jenkins
 canonical: 'https://www.checklyhq.com/docs/integrations/ci-cd/jenkins/overview/'
 ---

--- a/integrations/ci-cd/vercel/deployment-protection.mdx
+++ b/integrations/ci-cd/vercel/deployment-protection.mdx
@@ -1,5 +1,6 @@
 ---
 title: Vercel Deployment Protection
+description: "Let Checkly's browser checks reach protected Vercel preview and production deployments by passing a Protection Bypass for Automation secret in your tests."
 sidebarTitle: Deployment Protection
 canonical: 'https://www.checklyhq.com/docs/integrations/ci-cd/vercel/deployment-protection/'
 ---

--- a/integrations/ci-cd/vercel/managing-plan.mdx
+++ b/integrations/ci-cd/vercel/managing-plan.mdx
@@ -1,5 +1,6 @@
 ---
 title: Managing Users and Plans with Vercel
+description: "Manage Checkly users, plans, and billing through Vercel's native integration, adding team members and adjusting your plan from the Vercel dashboard."
 sidebarTitle: Managing Users and Plans
 canonical: 'https://www.checklyhq.com/docs/integrations/ci-cd/vercel/managing-plan/'
 ---

--- a/integrations/ci-cd/vercel/overview.mdx
+++ b/integrations/ci-cd/vercel/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Integrating Checkly in Vercel
+description: "Integrate Checkly with Vercel using the Marketplace and Connected integrations to manage your account and monitor preview and production deployments."
 sidebarTitle: Overview
 canonical: 'https://www.checklyhq.com/docs/integrations/ci-cd/vercel/overview/'
 ---

--- a/learn/overview.mdx
+++ b/learn/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Learn Concepts and Best Practices"
+description: "Learn the fundamentals of modern monitoring and observability, with practical guides on Playwright, testing, and building more reliable applications."
 sidebarTitle: "Overview"
 mode: "wide"
 canonical: 'https://www.checklyhq.com/docs/learn/overview/'

--- a/learn/playwright/bypass-totp.mdx
+++ b/learn/playwright/bypass-totp.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to Bypass Time-Based 2FA Login Flows With Playwright
+description: "Automate logins protected by time-based one-time password (TOTP) two-factor authentication in Playwright by generating valid passcodes inside your test."
 subTitle: Playwright for complex authentication tasks
 date: 2024-10-30
 author: Stefan Judis

--- a/learn/playwright/challenging-flows.mdx
+++ b/learn/playwright/challenging-flows.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to Handle Challenging Automation Flows in Playwright
+description: "Automate hard-to-test flows like signup, social login, and password reset in Playwright, and get past captchas and bot detection in test environments."
 subTitle: Automation countermeasures and shortcomings
 date: 2020-07-23
 author: Giovanni Rago

--- a/learn/playwright/checkout-testing-guide.mdx
+++ b/learn/playwright/checkout-testing-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: Mastering E2E Checkout Testing Using Playwright
+description: "Write end-to-end checkout tests with Playwright, adding products to a cart, entering billing details, and confirming the purchase completes successfully."
 subTitle: Filling a basket and completing the transaction
 date: 2020-07-02
 author: Giovanni Rago

--- a/learn/playwright/clicking-typing-hovering.mdx
+++ b/learn/playwright/clicking-typing-hovering.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to Click, Type, and Hover with Playwright
+description: "Replicate real user interactions in Playwright, clicking buttons, typing into fields, and hovering over elements using user-first selectors."
 subTitle: Basic page interactions
 date: 2020-06-15
 author:

--- a/learn/playwright/codegen.mdx
+++ b/learn/playwright/codegen.mdx
@@ -1,5 +1,6 @@
 ---
 title: Record Automation Scripts Using Playwright Codegen
+description: "Generate Playwright scripts automatically with the codegen command, recording your browser interactions into editable test code with user-first locators."
 subTitle: Automatically record playwright tests with codegen
 date: 2025-02-20
 author: Nočnica Mellifera

--- a/learn/playwright/debugging-errors.mdx
+++ b/learn/playwright/debugging-errors.mdx
@@ -1,5 +1,6 @@
 ---
 title: Playwright Debugging Errors - Common Issues and Solutions
+description: "Recognize common categories of Playwright errors and their obvious and non-obvious root causes, with links to fixes for the most frequent failures."
 subTitle: Recurring non-trivial debugging situations and how to solve them
 date: 2021-08-05
 author: Giovanni Rago

--- a/learn/playwright/debugging.mdx
+++ b/learn/playwright/debugging.mdx
@@ -1,5 +1,6 @@
 ---
 title: Playwright Debugging - Techniques for Script Troubleshooting
+description: "Troubleshoot failing Playwright scripts by reading error messages in context, understanding expected behavior, and using the right tools to gain visibility."
 subTitle: How to go about fixing what is not working
 date: 2021-07-26
 author: Giovanni Rago

--- a/learn/playwright/emulating-mobile-devices.mdx
+++ b/learn/playwright/emulating-mobile-devices.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to emulate mobile devices with Playwright
+description: "Emulate mobile devices in Playwright by setting viewport size, device pixel ratio, and user-agent strings to test responsive behavior across screens."
 subTitle: Learn how to emulate mobile devices
 date: 2022-07-19
 author:

--- a/learn/playwright/error-click-not-executed.mdx
+++ b/learn/playwright/error-click-not-executed.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to Fix the "Click Not Executed" Error in Playwright
+description: "Diagnose why a Playwright click seems to be ignored, from duplicate element IDs to the wrong element receiving the click, and use strict mode to catch it."
 date: 2021-11-18
 author: Giovanni Rago
 githubUser: ragog

--- a/learn/playwright/error-element-not-found.mdx
+++ b/learn/playwright/error-element-not-found.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to Fix 'Element Not Found' Errors in Playwright
+description: "Fix Playwright's element not found error, from wrong selectors and missing waits to a previous click that silently left you on the wrong page."
 date: 2021-08-05
 author: Giovanni Rago
 githubUser: ragog

--- a/learn/playwright/error-element-not-visible.mdx
+++ b/learn/playwright/error-element-not-visible.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to Fix "Element Not Visible" Error in Playwright
+description: "Fix Playwright's element not visible error by checking whether an element is hidden or covered by another, using headful mode and screenshots to confirm state."
 date: 2021-08-05
 author: Giovanni Rago
 githubUser: ragog

--- a/learn/playwright/error-target-closed.mdx
+++ b/learn/playwright/error-target-closed.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to Fix "Target Closed" Error in Playwright
+description: "Understand and fix Playwright's Target closed error, usually caused by a browser, context, or tab closing too early or a missing await on a promise."
 date: 2021-08-05
 author: Giovanni Rago
 githubUser: ragog

--- a/learn/playwright/error-wait-not-respected.mdx
+++ b/learn/playwright/error-wait-not-respected.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to Fix "Wait Not Respected" Error in Playwright
+description: "Fix Playwright waits that seem ignored, usually because the element already matches your state requirement, and confirm element state in the browser console."
 date: 2021-08-05
 author: Giovanni Rago
 githubUser: ragog

--- a/learn/playwright/file-download.mdx
+++ b/learn/playwright/file-download.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to Download Files with Playwright
+description: "Download files with Playwright and verify them against a fixture, using either the download event or extracting the href and fetching it with an HTTP request."
 subTitle: Different ways of handling downloads
 date: 2020-09-09
 author: Giovanni Rago

--- a/learn/playwright/generating-pdfs.mdx
+++ b/learn/playwright/generating-pdfs.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to Generate PDFs with Playwright
+description: "Generate PDFs from web pages with Playwright's page.pdf() command and customize the output for archiving, invoices, and other document automation."
 subTitle: Creating invoices, books and more from a web page
 date: 2020-11-19
 author: Giovanni Rago

--- a/learn/playwright/google-login-automation.mdx
+++ b/learn/playwright/google-login-automation.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to Automate Google Login with Playwright
+description: "Automate social login with a Google account in Playwright, injecting credentials through environment variables to sign in via an OAuth provider flow."
 subTitle: Dealing with Google authentication
 date: 2020-06-22
 author: Tim Nolet

--- a/learn/playwright/handling-test-data.mdx
+++ b/learn/playwright/handling-test-data.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to Handle Test Data with Playwright
+description: "Keep Playwright tests DRY by factoring out test data and fixtures into dedicated files, so complex end-to-end scenarios stay readable and maintainable."
 subTitle: Introduction to fixture handling
 date: 2020-07-16
 author: Giovanni Rago

--- a/learn/playwright/how-to-detect-broken-links.mdx
+++ b/learn/playwright/how-to-detect-broken-links.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to detect broken links using Playwright
+description: "Detect broken links on a page with Playwright by extracting every link and checking each URL's status code, then monitor for 404s with Checkly."
 displayTitle: How to detect broken links using Playwright
 date: 2024-11-07
 author: Giovanni Rago

--- a/learn/playwright/how-to-parameterize-playwright-projects.mdx
+++ b/learn/playwright/how-to-parameterize-playwright-projects.mdx
@@ -1,5 +1,6 @@
 ---
 title: Parameterizing your Playwright projects
+description: "Pass configuration options to Playwright fixtures and page object models, so you can parameterize page objects and your entire project cleanly."
 displayTitle: Parameterizing Playwright Projects
 date: 2020-07-13
 author: Giovanni Rago

--- a/learn/playwright/how-to-search.mdx
+++ b/learn/playwright/how-to-search.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to search with Playwright
+description: "Test a site's search function end to end with Playwright by entering a term and asserting the expected number and content of results are shown."
 subTitle: Verifying core platform functionality
 date: 2020-07-15
 author: Giovanni Rago

--- a/learn/playwright/how-to-set-up-locally.mdx
+++ b/learn/playwright/how-to-set-up-locally.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to Set Up Playwright Locally
+description: "Install Playwright locally with a single npm command and run your first browser automation script, using Node.js and the bundled browser."
 date: 2020-06-20
 author: Giovanni Rago
 githubUser: ragog

--- a/learn/playwright/iframe-interaction.mdx
+++ b/learn/playwright/iframe-interaction.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to Handle iFrames in Playwright
+description: "Access and interact with iframe content in Playwright using frameLocator to query elements inside a frame as if you were in the page context."
 subTitle: Accessing and interacting with iframes
 date: 2022-08-25
 author: Stefan Judis

--- a/learn/playwright/intercept-requests.mdx
+++ b/learn/playwright/intercept-requests.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to Intercept Requests in Playwright
+description: "Observe and manipulate network traffic in Playwright by intercepting requests and responses, logging them or modifying them during a test."
 subTitle: Monitoring and manipulating web traffic
 date: 2020-09-03
 author:

--- a/learn/playwright/login-automation.mdx
+++ b/learn/playwright/login-automation.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to Automate Login with Playwright
+description: "Automate a standard username-and-password login flow with Playwright and assert it succeeded by checking for an element only visible to logged-in users."
 subTitle: Automating one of the most common scenarios
 date: 2020-06-25
 author: Giovanni Rago

--- a/learn/playwright/microsoft-login-automation.mdx
+++ b/learn/playwright/microsoft-login-automation.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to Automate Microsoft Live Login with Playwright
+description: "Automate signing in to a Microsoft Live account with Playwright, injecting credentials through environment variables to reach the account page."
 subTitle: Dealing with Microsoft authentication
 date: 2020-06-22
 author: Tim Nolet

--- a/learn/playwright/mock-api.mdx
+++ b/learn/playwright/mock-api.mdx
@@ -1,5 +1,6 @@
 ---
 title: Test Dynamic Content by Mocking API Responses
+description: "Stabilize tests for dynamic pages by mocking API responses in Playwright, fixing unpredictable data like stock counts while leaving the rest of the page live."
 subTitle: Manipulating and mocking API responses
 date: 2025-03-12
 author:

--- a/learn/playwright/multitab-flows.mdx
+++ b/learn/playwright/multitab-flows.mdx
@@ -1,5 +1,6 @@
 ---
 title: Handling Multiple Tabs with Playwright
+description: "Control multiple browser tabs in Playwright, opening new pages in a context and interacting with each independently within a single test."
 subTitle: Controlling multiple tabs
 date: 2021-08-29
 author: Giovanni Rago

--- a/learn/playwright/performance.mdx
+++ b/learn/playwright/performance.mdx
@@ -1,5 +1,6 @@
 ---
 title: Measuring Page Performance Using Playwright - Best Practices
+description: "Measure web page performance with Playwright, understand why speed affects users and revenue, and track browser performance metrics over time."
 subTitle: Explaining why it matters and how to assess it
 date: 2020-09-30
 author: Giovanni Rago

--- a/learn/playwright/scraping-behind-login.mdx
+++ b/learn/playwright/scraping-behind-login.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to Scrape Data Behind a Login with Playwright
+description: "Scrape data that sits behind a login wall with Playwright by combining UI automation and scraping, illustrated by totalling Amazon order history."
 subTitle: An example in accessing account-specific information
 date: 2020-12-23
 author: Giovanni Rago

--- a/learn/playwright/script-recorders.mdx
+++ b/learn/playwright/script-recorders.mdx
@@ -1,5 +1,6 @@
 ---
 title: Using Script Recorders with Playwright
+description: "Speed up script creation with Playwright recorders like codegen and the VS Code extension, then refine the generated selectors and waits for reliability."
 subTitle: Generating scripts for beginners and pros
 date: 2020-09-16
 author: Hannes Lenke

--- a/learn/playwright/steps-decorators.mdx
+++ b/learn/playwright/steps-decorators.mdx
@@ -1,5 +1,6 @@
 ---
 title: Self-documenting tests - add automatic Playwright steps with Typescript Decorators
+description: "Structure complex Playwright tests with a single @step TypeScript decorator, replacing repetitive test.step calls to make reports easier to scan."
 subTitle: Understand tests better with steps
 date: 2024-11-15
 author: Stefan Judis

--- a/learn/playwright/taking-screenshots.mdx
+++ b/learn/playwright/taking-screenshots.mdx
@@ -1,5 +1,6 @@
 ---
 title: Playwright Screenshots - How to Take and  Automate Screenshots
+description: "Capture screenshots with Playwright's page.screenshot command, take full-page images, and automate visual comparisons to catch regressions."
 subTitle: Leveraging images for troubleshooting and more
 date: 2020-06-23
 author: Giovanni Rago

--- a/learn/playwright/test-fixtures.mdx
+++ b/learn/playwright/test-fixtures.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reuse code with custom test fixtures in Playwright
+description: "Share setup and logic across Playwright tests with custom fixtures, extending built-ins like page and context to keep your test base DRY and maintainable."
 subTitle: Implement DRY practices by customizing your test environment
 date: 2024-03-16
 author: Nocnica Mellifera

--- a/learn/playwright/testing-apis.mdx
+++ b/learn/playwright/testing-apis.mdx
@@ -1,5 +1,6 @@
 ---
 title: Testing APIs with Playwright
+description: "Use Playwright's request fixture to test REST and GraphQL APIs directly, sending requests and asserting on responses without opening a browser."
 displayTitle: Using Playwright to test APIs
 date: 2020-07-13
 author: Giovanni Rago

--- a/learn/playwright/testing-coupons.mdx
+++ b/learn/playwright/testing-coupons.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to Test Coupons and Discounts with Playwright
+description: "Verify coupon and discount codes with Playwright by adding items to a cart and asserting the total price changes by the expected amount after applying the code."
 subTitle: Applying and verifying a discount
 date: 2020-07-13
 author: Giovanni Rago

--- a/learn/playwright/testing-file-uploads.mdx
+++ b/learn/playwright/testing-file-uploads.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to Test File Uploads with Playwright
+description: "Test file upload functionality with Playwright by logging in and attaching a file, using a profile-image upload as a worked example."
 subTitle: Modifying account settings with a file upload
 date: 2020-07-22
 author: Giovanni Rago

--- a/learn/playwright/testing-in-parallel.mdx
+++ b/learn/playwright/testing-in-parallel.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to run Playwright tests in parallel
+description: "Run Playwright tests in parallel or in sequence, distinguishing stateless from stateful tests to avoid conflicts and speed up your suite."
 displayTitle: How to run Playwright tests in parallel
 date: 2024-11-08
 author: Giovanni Rago

--- a/learn/playwright/user-signup-automation.mdx
+++ b/learn/playwright/user-signup-automation.mdx
@@ -1,5 +1,6 @@
 ---
 title: Automating User Signup with Playwright
+description: "Automate user signup flows with Playwright by filling registration forms, submitting them, and confirming the account was created through a UI change."
 subTitle: Handling signups flows
 date: 2020-06-30
 author: Giovanni Rago

--- a/learn/playwright/waits-and-timeouts.mdx
+++ b/learn/playwright/waits-and-timeouts.mdx
@@ -1,5 +1,6 @@
 ---
 title: Dealing with waits and timeouts in Playwright
+description: "Replace flaky hard-coded timeouts in Playwright with auto-waiting and web-first assertions to make your tests faster and more reliable."
 date: 2021-11-26
 author: Giovanni Rago
 githubUser: ragog

--- a/learn/playwright/web-scraping.mdx
+++ b/learn/playwright/web-scraping.mdx
@@ -1,5 +1,6 @@
 ---
 title: Playwright Web Scraping - How to Extract Data from Websites
+description: "Extract data from web pages with Playwright, reading element attributes and properties for testing assertions or general-purpose scraping."
 subTitle: Extracting valuable information through automation
 date: 2020-08-26
 author: Giovanni Rago

--- a/learn/playwright/writing-tests.mdx
+++ b/learn/playwright/writing-tests.mdx
@@ -1,5 +1,6 @@
 ---
 title: Best Practices for Writing Tests in Playwright
+description: "Write valuable, maintainable Playwright tests by keeping scripts short, simple, and readable, so they keep telling the truth about your system as it evolves."
 subTitle: Principles for sustainable automated testing
 date: 2020-07-16
 author: Giovanni Rago

--- a/platform/ip-information.mdx
+++ b/platform/ip-information.mdx
@@ -1,5 +1,6 @@
 ---
 title: IP Information & Versions
+description: "Understand Checkly's dual-stack IPv4 and IPv6 support, how address resolution is prioritized, and where to find the static IP ranges for allowlisting."
 sidebarTitle: IP Information
 tags: ['ip-information']
 canonical: 'https://www.checklyhq.com/docs/platform/ip-information/'

--- a/platform/private-locations/agent-configuration.mdx
+++ b/platform/private-locations/agent-configuration.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Agent Configuration'
+description: "Configure the Checkly Agent for a private location with environment variables for API keys, proxies, job concurrency, log level, and dependency caching."
 canonical: 'https://www.checklyhq.com/docs/platform/private-locations/agent-configuration/'
 ---
 

--- a/platform/private-locations/agent-images.mdx
+++ b/platform/private-locations/agent-images.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Agent Images'
+description: "Compare the Checkly Agent images, Standard, Dev, and Uptime, and learn the image tag format for pulling the variant and version you need."
 sidebarTitle: 'Agent Images'
 canonical: 'https://www.checklyhq.com/docs/platform/private-locations/agent-images/'
 ---

--- a/platform/private-locations/kubernetes-deployment.mdx
+++ b/platform/private-locations/kubernetes-deployment.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Kubernetes Deployment'
+description: "Deploy the Checkly Agent to a private location on Kubernetes using the official Helm chart for production-grade, orchestrated agent deployments."
 canonical: 'https://www.checklyhq.com/docs/platform/private-locations/kubernetes-deployment/'
 ---
 

--- a/platform/reporting/analytics-api.mdx
+++ b/platform/reporting/analytics-api.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Analytics API'
+description: "Query Checkly check metrics with the Analytics API, returning aggregated or raw data points grouped by location or time window for your own reporting tools."
 sidebarTitle: 'Analytics API'
 canonical: 'https://www.checklyhq.com/docs/platform/reporting/analytics-api/'
 ---

--- a/resolve/traces/import/overview.mdx
+++ b/resolve/traces/import/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Importing Traces To Checkly"
+description: "Send OpenTelemetry traces from your infrastructure to Checkly so you can drill into why a check failed or degraded, right from the check result."
 
 sidebarTitle: "Importing Traces"
 canonical: 'https://www.checklyhq.com/docs/resolve/traces/import/overview/'


### PR DESCRIPTION
## Why

Part of an AEO (answer-engine optimization) audit — making sure the docs are easy for AI agents to summarize and cite.

**71 published content pages had no `description` in frontmatter** (41 of them in `learn/playwright/`, the highest-citation-value section). The effect was concrete:

- They appeared in `/docs/llms.txt` as **bare links with no summary**, so an agent scanning the index has nothing to rank them on.
- Their `<meta name="description">` rendered **empty or fell back to the global site description**, weakening AI snippets and SEO.

Verified live before this change: e.g. `learn/playwright/login-automation` rendered no description tag and showed a bare link in llms.txt, while pages that *had* a description (e.g. `what-is-playwright`) showed a proper summary in both places.

## What

Adds a one-line `description:` to each of the 71 pages, inserted right after `title:`.

- Each description is **written from the page's actual content**, not generated boilerplate, and matches the existing docs voice.
- **1 line changed per file**, 71 insertions total — no other edits.
- Frontmatter validated with a YAML parser; re-audit confirms **0 real-content pages remain without a description**.

## Out of scope

- **API-reference pages** are intentionally untouched — Mintlify sources their title/description from the OpenAPI spec at render time.
- Two other audit findings are **not** in this PR: sitemap fragmentation (`/docs-sitemap.xml`=903 vs repo `sitemap.xml`=570 vs Mintlify native=1,099) and thin structured data (only generic `WebSite` JSON-LD). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)