### PR TITLE
Add Vercel Web Analytics to docs site

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -22,6 +22,9 @@
     },
     {
       "src": "/unify-tracking.js"
+    },
+    {
+      "src": "/vercel-analytics.js"
     }
   ],
   "integrations": {

--- a/vercel-analytics.js
+++ b/vercel-analytics.js
@@ -1,0 +1,12 @@
+// Vercel Web Analytics
+// These docs are served under checklyhq.com/docs via a Vercel rewrite, so the
+// insights script and its beacon only resolve at the domain root. A path
+// relative to /docs 404s.
+(function () {
+  if (window.__vercelInsightsAdded) return;
+  window.__vercelInsightsAdded = true;
+
+  var script = document.createElement('script');
+  script.src = '/_vercel/insights/script.js';
+  document.head.appendChild(script);
+})();


### PR DESCRIPTION
## What

Adds Vercel Web Analytics to the docs site, matching what we have on the marketing site.

- `vercel-analytics.js` (new) — appends the Vercel insights script to the page head
- `docs.json` — registers it in the existing `script` array, alongside `block-headless.js` and `unify-tracking.js`

## Why this can't live in the marketing repo

The marketing site's `<Analytics />` only runs on pages Next.js actually renders. `/docs/*` is a rewrite — Vercel proxies the HTML straight from Mintlify, so our React tree never touches these pages. Confirmed: the live docs HTML contains no Vercel insights script.

Docs share an origin with the marketing site (`checklyhq.com/docs/`), so the script already served at `/_vercel/insights/script.js` loads fine and beacons back to `/_vercel/insights/view` on our project with correct attribution. Mintlify's `docs.json` analytics integrations are a fixed list (GA4, GTM, Amplitude, PostHog, Segment, Plausible…) and Vercel isn't on it, so a custom script is the way in.

**The absolute path matters** — `/docs/_vercel/insights/script.js` 404s, only the root path resolves.

## Verification

Tested against the live production docs before opening this, with beacons intercepted so no real analytics data was written:

| Check | Result |
|---|---|
| `/_vercel/insights/script.js` from docs origin | 200 |
| `/docs/_vercel/insights/script.js` | 404 (hence the absolute path) |
| Initial pageview | fires → `https://www.checklyhq.com/docs/` |
| Client-side sidebar navigation | fires a **distinct** second pageview → `https://www.checklyhq.com/docs/what-is-checkly/` |

The SPA concern is resolved: Mintlify's docs site is a client-routed Next.js app, but the insights script patches `history.pushState` and listens for `popstate`, so page-to-page clicks are tracked as separate paths rather than collapsing into the entry page. Confirmed the navigation was genuine client-side routing (no page reload).

Mintlify inlines custom script contents into each page, so this executes exactly once per page load — no double-counting.

## Before merging: check the event quota

Vercel Web Analytics bills per event, and docs are a large share of our traffic. This will move the meter more than the marketing site does. Worth a look at the plan's included events first — that's the main reason to hold this.

Minor bonus: the insights script self-blocks headless browsers (`navigator.webdriver`, `Headless` in the UA), so bot traffic won't inflate the count. On Mintlify preview deploys / the raw `mintlify.dev` domain the script just 404s harmlessly, since `/_vercel` only exists on the Vercel-fronted origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)